### PR TITLE
Generalized tuple SimpleLens to Lens.

### DIFF
--- a/core/src/main/scala/monocle/std/Tuple.scala
+++ b/core/src/main/scala/monocle/std/Tuple.scala
@@ -1,12 +1,12 @@
 package monocle.std
 
-import monocle.SimpleLens
+import monocle.Lens
 
 object tuple extends TupleInstances
 
 trait TupleInstances {
 
-  def _1[A, B]: SimpleLens[(A, B), A] = SimpleLens(_._1, (pair, s) => pair.copy(_1 = s))
-  def _2[A, B]: SimpleLens[(A, B), B] = SimpleLens(_._2, (pair, t) => pair.copy(_2 = t))
+  def _1[A, B, New]: Lens[(A, B), (New,B), A, New] = Lens(_._1, (pair, n) => pair.copy(_1 = n))
+  def _2[A, B, New]: Lens[(A, B), (A,New), B, New] = Lens(_._2, (pair, n) => pair.copy(_2 = n))
 
 }

--- a/examples/src/main/scala/monocle/TupleExample.scala
+++ b/examples/src/main/scala/monocle/TupleExample.scala
@@ -1,0 +1,11 @@
+//Created By Ilan Godik
+package monocle
+
+import monocle.std.tuple._
+
+object TupleExample extends App {
+
+  println(_1[Int,String,Double].set((5,"Hello"), 7.3)) // (7.3,Hello)
+  println(_2[String,Int,Char].set(("Hello",5),'H')) // (Hello,H)
+
+}


### PR DESCRIPTION
Generalized tuple SimpleLens to Lens.

I'm unsure about the parameter order, 
What there is now:
first[A,New,B]
second[A,B,New]

Another option:
first[A,B,New]
second[A,B,New]
