### PR TITLE
Update Scala Macros to stable 2.0.0

### DIFF
--- a/core/src/main/scala/monocle/Macro.scala
+++ b/core/src/main/scala/monocle/Macro.scala
@@ -32,7 +32,7 @@ private[monocle] object MacroImpl {
     val strFieldName = c.eval(c.Expr[String](c.resetAllAttrs(fieldName.tree.duplicate)))
 
     val fieldMethod = aTpe.declarations.collectFirst {
-      case m: MethodSymbol if m.isCaseAccessor && m.name.decoded == strFieldName => m.name
+      case m: MethodSymbol if m.isCaseAccessor && m.name.decoded == strFieldName => m
     }.getOrElse(c.abort(c.enclosingPosition, s"Cannot find method $strFieldName in $aTpe"))
 
     c.Expr[B](q"""{(a: $aTpe) => a.$fieldMethod}""")
@@ -50,7 +50,7 @@ private[monocle] object MacroImpl {
 
     val field = constructor.paramss.head.find(_.name.decoded == strFieldName).getOrElse(c.abort(c.enclosingPosition, s"Cannot find constructor field named $fieldName in $aTpe"))
 
-    c.Expr[(A, B) => A](q"{(a: $aTpe, b: $bTpe) => a.copy(${field.name} = b)}")
+    c.Expr[(A, B) => A](q"{(a: $aTpe, b: $bTpe) => a.copy(${field} = b)}")
   }
 
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -17,7 +17,7 @@ object BuildSettings {
     incOptions        := incOptions.value.withNameHashing(true),
     resolvers         += Resolver.sonatypeRepo("releases"),
     resolvers         += Resolver.sonatypeRepo("snapshots"),
-    addCompilerPlugin("org.scalamacros" % "paradise" % "2.0.0-M3" cross CrossVersion.full)
+    addCompilerPlugin("org.scalamacros" % "paradise" % "2.0.0" cross CrossVersion.full)
   )  ++ publishSettings
 }
 
@@ -31,7 +31,7 @@ object Dependencies {
   val specs2            = "org.specs2"      %% "specs2"                    % "1.12.3"       % "test"
   val scalazSpec2       = "org.typelevel"   %% "scalaz-specs2"             % "0.1.5"        % "test"
   val scalaReflect      = "org.scala-lang"  %  "scala-reflect"             % BuildSettings.buildScalaVersion
-  val quasiquotes       = "org.scalamacros" %  "quasiquotes"               % "2.0.0-M3" cross CrossVersion.full
+  val quasiquotes       = "org.scalamacros" %  "quasiquotes"               % "2.0.0" cross CrossVersion.binary
   val testsDep          = Seq(scalaCheck, scalaCheckBinding, specs2, scalazSpec2)
   val macrosDep         = Seq(scalaReflect, quasiquotes)
   val shapelessDep      = Seq(shapeless, shapelessCheck, shapelessZ)


### PR DESCRIPTION
Scala Macros (paradise and quasiquotes) have reached a stable 2.0.0 version. Between M3 and the stable version, there's been a refactor that cause [cross-version conflicts between libraries with no great workaround](http://stackoverflow.com/a/23150477). For example, it is currently not possible to compile a project using both Monocle and Spire, which uses the 2.0.0 release of Scala Macros.

This updates each of the libraries and fixes a small API change.
