### PR TITLE
Add optics for `scalaz.Validation` #153

### DIFF
--- a/core/src/main/scala/monocle/std/StdInstances.scala
+++ b/core/src/main/scala/monocle/std/StdInstances.scala
@@ -31,3 +31,4 @@ trait StdInstances
   with    NonEmptyListInstances
   with    OneAndInstances
   with    TreeFunctions with TreeInstances
+  with    ValidationFunctions

--- a/core/src/main/scala/monocle/std/Validation.scala
+++ b/core/src/main/scala/monocle/std/Validation.scala
@@ -1,0 +1,20 @@
+package monocle.std
+
+import monocle.{Prism}
+import scalaz.{Validation, Maybe, Success, Failure}
+import Maybe.{Just, Empty}
+
+object validation extends ValidationFunctions
+
+trait ValidationFunctions {
+
+  def success[E, A]: Prism[Validation[E, A], A] =
+    Prism[Validation[E, A], A](_.toMaybe)(Success.apply)
+
+  def failure[E, A]: Prism[Validation[E, A], E] =
+    Prism[Validation[E, A], E]{
+      case Success(a) => Empty()
+      case Failure(e) => Just(e)
+    }(Failure.apply)
+
+}

--- a/test/src/test/scala/monocle/TestUtil.scala
+++ b/test/src/test/scala/monocle/TestUtil.scala
@@ -88,6 +88,11 @@ object TestUtil {
     3 -> Arbitrary.arbitrary[A].map(Maybe.just(_))
   ))
 
+  implicit def validationArbitrary[E: Arbitrary, A: Arbitrary]: Arbitrary[Validation[E, A]] = Arbitrary(Gen.frequency(
+    1 -> Arbitrary.arbitrary[E].map(Failure.apply),
+    3 -> Arbitrary.arbitrary[A].map(Success.apply)
+  ))
+
   implicit def someArbitrary[A: Arbitrary]: Arbitrary[Some[A]] = Arbitrary(Arbitrary.arbitrary[A].map(Some(_)))
 
   implicit def disjunctionArbitrary[A: Arbitrary, B: Arbitrary]: Arbitrary[A \/ B] =

--- a/test/src/test/scala/monocle/std/ValidationSpec.scala
+++ b/test/src/test/scala/monocle/std/ValidationSpec.scala
@@ -1,0 +1,12 @@
+package monocle.std
+
+import monocle.TestUtil._
+import monocle.law.{PrismLaws}
+import org.specs2.scalaz.Spec
+
+class ValidationSpec extends Spec {
+
+  checkAll("success", PrismLaws(validation.success[String, Int]))
+  checkAll("failure", PrismLaws(validation.failure[String, Int]))
+
+}


### PR DESCRIPTION
This is my initial attempt at implementing #153, "add optics for `scalaz.Validation".

This PR includes:
* `def success[E, A]: Prism[Validation[E, A], A]`.
* `def failure[E, A]: Prism[Validation[E, A], E]`,
* `implicit def validationArbitrary[E: Arbitrary, A: Arbitrary]: Arbitrary[Validation[E, A]]`, as was needed for `scalacheck` to work correctly with `scalaz.Validation`.

Some questions I still have:
* Are the names `success` and `failure` potentially too collision-prone? Should they be renamed or gain an additional prefix, e.g. `scalazSuccess` and `scalazFailure`?
* What is the meaning of `def validationToMaybe[E, A]: Optional[Validation[E, A], Maybe[A]]`? What should it produce in the `Success` case? What should it produce in the `Failure` case?
* In tests, I needed to explicitly refer to `validation.success` and `validation.failure`. I notice that the linked example `EitherSpec` directly refers to `stdLeft` and `stdRight`. Do I need to add another alias somewhere for `success` and `failure`?

Thanks in advance for clarifications!