### PR TITLE
Fix #190 Allow users to create new PLens

### DIFF
--- a/core/src/main/scala/monocle/Lens.scala
+++ b/core/src/main/scala/monocle/Lens.scala
@@ -30,7 +30,7 @@ import scalaz.{Applicative, Choice, Functor, Maybe, Monoid, Split, \/}
  * @tparam A the target of a [[PLens]]
  * @tparam B the modified target of a [[PLens]]
  */
-abstract class PLens[S, T, A, B] private[monocle]{ self =>
+abstract class PLens[S, T, A, B] { self =>
 
   /** get the target of a [[PLens]] */
   def get(s: S): A

--- a/test/src/test/scala/user/Visbility.scala
+++ b/test/src/test/scala/user/Visbility.scala
@@ -1,0 +1,12 @@
+package user
+
+class Visbility {
+
+  /* Macro should work outside of monocle package */
+  import monocle.macros.GenLens
+  case class Foo(n: Int)
+  object Foo {
+    val lens = GenLens[Foo](_.n)
+  }
+}
+


### PR DESCRIPTION
As compared to creating lenses with `PLens.apply`, creating lenses with `new PLens { ... }` results in lenses which are -18% to 78% faster in various [benchmarks](https://github.com/julien-truffaut/Monocle/wiki/Lens-Benchmark).

We had hoped that we could use macros to inline these new PLenses in user code, but unfortunately package private access restrictions are enforced on the expanded macros.  

Since macros essentially insert Scala source, I don't think we can inline code that would violate JVM permissions. :disappointed: 