### PR TITLE
Syntactic sugar for ad-hoc creation and use of lenses.

### DIFF
--- a/example/src/test/scala/monocle/LensExample.scala
+++ b/example/src/test/scala/monocle/LensExample.scala
@@ -1,6 +1,6 @@
 package monocle
 
-import monocle.macros.{GenLens, Lenses}
+import monocle.macros.{GenLens, Lenses, Focus, focus, FocusOps}
 import org.specs2.execute.AnyValueAsResult
 import org.specs2.scalaz.Spec
 import shapeless.test.illTyped
@@ -32,6 +32,10 @@ class LensExample extends Spec {
       Manual._name.get(john) ==== "John"
       Semi.name.get(john)    ==== "John"
       Person.name.get(john)  ==== "John"
+      Focus(john)(_.name).get ==== "John"
+      focus(john)(_.name).get ==== "John"
+      john.focus.name.get ==== "John"
+      john.name ==== "John"
     }
 
     "set" in {
@@ -40,12 +44,23 @@ class LensExample extends Spec {
       Manual._age.set(45)(john) ==== changedJohn
       Semi.age.set(45)(john)    ==== changedJohn
       Person.age.set(45)(john)  ==== changedJohn
+      Focus(john)(_.age).set(45) ==== changedJohn
+      (Focus(john)(_.age) = 45) ==== changedJohn
+      focus(john)(_.age).set(45) ==== changedJohn
+      (focus(john)(_.age) = 45) ==== changedJohn
+      (john.focus(_.age) = 45) ==== changedJohn
+      (john.focus.age = 45) ==== changedJohn
     }
 
     "compose" in {
       (Manual._address composeLens Manual._streetNumber).get(john) ==== 126
       (Semi.address composeLens Semi.streetNumber).get(john)       ==== 126
       (Person.address composeLens Address.streetNumber).get(john)  ==== 126
+      Focus(john)(_.address.streetNumber).get ==== 126
+      john.focus(_.address.streetNumber).get ==== 126
+      focus(john).address.streetNumber.get ==== 126
+      john.focus.address.streetNumber.get ==== 126
+      john.address.streetNumber ==== 126
     }
 
     @Lenses("_") // this generates lenses prefixed with _ in the Cat companion object

--- a/macro/src/main/scala-2.10/monocle.macros.internal/MacrosCompatibility.scala
+++ b/macro/src/main/scala-2.10/monocle.macros.internal/MacrosCompatibility.scala
@@ -2,6 +2,7 @@ package monocle.macros.internal
 
 trait MacrosCompatibility {
   type Context = scala.reflect.macros.Context
+  type WhiteboxContext = scala.reflect.macros.Context
 
   def getDeclarations(c: Context)(tpe: c.universe.Type): c.universe.MemberScope =
     tpe.declarations

--- a/macro/src/main/scala-2.11/monocle.macros.internal/MacrosCompatibility.scala
+++ b/macro/src/main/scala-2.11/monocle.macros.internal/MacrosCompatibility.scala
@@ -2,6 +2,7 @@ package monocle.macros.internal
 
 trait MacrosCompatibility {
   type Context = scala.reflect.macros.blackbox.Context
+  type WhiteboxContext = scala.reflect.macros.whitebox.Context
 
   def getDeclarations(c: Context)(tpe: c.universe.Type): c.universe.MemberScope =
     tpe.decls

--- a/macro/src/main/scala/monocle/macros/Focus.scala
+++ b/macro/src/main/scala/monocle/macros/Focus.scala
@@ -1,0 +1,35 @@
+package monocle.macros
+
+import scala.language.dynamics
+
+import monocle._
+import monocle.syntax.ApplyLens
+
+/** Syntactic sugar around an ApplyLens */
+class Focus[S,A](val applyLens: ApplyLens[S,S,A,A]) extends AnyVal with Dynamic{
+  def apply[C](field: A => C): Focus[S,C] = macro internal.FocusImpl.apply[S,A,C]
+
+  /**
+  Whitebox macro for field access syntax.
+  E.g. someobj.focus.a.b...
+  */
+  def selectDynamic(field: String): Any = macro internal.FocusImpl.selectDynamicImpl
+  
+  /**
+  Assignment syntax for updates
+  E.g. someobj.focus(_.a.b) = ...
+  */
+  def update[C](field: A => C, value: C): S = macro internal.FocusImpl.update[S,A,C]
+  /**
+  Assignment syntax for updates with member access syntax
+  E.g. someobj.focus.a.b = ...
+  */
+  def updateDynamic[C](field: String)(value: C): S = macro internal.FocusImpl.updateDynamicImpl[S,C]
+  
+  def get: A = applyLens.get
+  def set(value: A): S = applyLens.set(value)
+  def modify(diff: A => A): S = applyLens.modify(diff)
+}
+object Focus{
+  def apply[S](value: S) = new Focus(ApplyLens[S,S,S,S]( value, Lens.id ))
+}

--- a/macro/src/main/scala/monocle/macros/package.scala
+++ b/macro/src/main/scala/monocle/macros/package.scala
@@ -1,0 +1,17 @@
+package monocle.macros
+import monocle.syntax.ApplyLens
+import monocle._
+object `package`{
+  /**
+  Function-style Focus constructor for any object
+  E.g. focus(someobj)...
+  */
+  def focus[S](value: S) = Focus(value)
+  implicit class FocusOps[S](value: S){
+    /**
+    Inline Focus constructor for any object
+    E.g. someobj.focus...
+    */
+    def focus = new Focus(ApplyLens[S,S,S,S]( value, Lens.id ))
+  }
+}


### PR DESCRIPTION
This is my take on syntax I promised. I currently have 3 alternatives for creating "Focus" objects, which are my macro-enabled variant of ApplyLens. Focus(obj), focus(obj), obj.focus. I like the last best, but it requires an implicit conversion on an unconstrained type, which may not be desirable, hence the 1st and 2nd version. We may want to get rid of 1 or 2 of them.

Also I implemented support for the assignment operator (.update / .updateDynamic).

Selecting fields directly on Focus is also nice, but requires a whitebox macro, which is why there is a non-whitebox fallback, which is .apply and passing a function that does the member access.

Personally my most common use case for lenses would be `john.focus.age = 45` or if workign in IntelliJ maybe `john.focus(_.age) = 45`. This syntax would make my life much easier.

WDYT?