### PR TITLE
add optics for scalaz.Validation

### DIFF
--- a/core/src/main/scala/monocle/std/StdInstances.scala
+++ b/core/src/main/scala/monocle/std/StdInstances.scala
@@ -31,3 +31,4 @@ trait StdInstances
   with    NonEmptyListInstances
   with    OneAndInstances
   with    TreeFunctions with TreeInstances
+  with    ValidationFunctions

--- a/core/src/main/scala/monocle/std/Validation.scala
+++ b/core/src/main/scala/monocle/std/Validation.scala
@@ -1,0 +1,24 @@
+package monocle.std
+
+import monocle.{PIso, PPrism}
+
+import scalaz.syntax.either._
+import scalaz.syntax.validation._
+import scalaz.{Validation, \/}
+
+object validation extends ValidationFunctions
+
+trait ValidationFunctions {
+  final def success[E, A, B]: PPrism[Validation[E, A], Validation[E, B], A, B] =
+    PPrism[Validation[E, A], Validation[E, B], A, B](
+      _.fold(e => Validation.failure[E, B](e).left[A], a => a.right[Validation[E, B]])
+    )(_.success[E])
+
+  final def failure[E, A, B]: PPrism[Validation[E, A], Validation[B, A], E, B] =
+    PPrism[Validation[E, A], Validation[B, A], E, B](
+      _.fold(e => e.right[Validation[B, A]], a => Validation.success[B, A](a).left[E])
+    )(_.failure[A])
+
+  final def disjunctionIso[E1, E2, A1, A2]: PIso[Validation[E1, A1], Validation[E2, A2], E1 \/ A1, E2 \/ A2] =
+    PIso[Validation[E1, A1], Validation[E2, A2], E1 \/ A1, E2 \/ A2](_.disjunction)(_.validation)
+}

--- a/example/src/test/scala/monocle/std/ValidationExample.scala
+++ b/example/src/test/scala/monocle/std/ValidationExample.scala
@@ -1,0 +1,42 @@
+package monocle.std
+
+import org.specs2.scalaz.{ScalazMatchers, Spec}
+
+import monocle.std.{validation => mValidation}
+
+import scalaz.syntax.validation._
+import scalaz.syntax.either._
+
+class ValidationExample extends Spec {
+  "success defines a Prism that can get, set or modify the underlying value of a Success instance" in {
+    mValidation.success.getOrModify(123.success) ==== 123.right
+    mValidation.success.getOrModify("abc".failure) ==== "abc".failure.left
+
+    mValidation.success.getOption(123.success) ==== Some(123)
+    mValidation.success.getOption("abc".failure) ==== None
+
+    mValidation.success.reverseGet(123) ==== 123.success
+
+    mValidation.success.set('a')(123.success) ==== 'a'.success
+    mValidation.success.set(123)("e".failure) ==== "e".failure
+
+    mValidation.success[String, Int, Double].modify(_ + 2.34D)(10.success) ==== 12.34D.success
+    mValidation.success[String, String, Int].modify(_.toInt)("abc".failure) ==== "abc".failure
+  }
+
+  "failure defines a Prism that can get, set or modify the underlying value of a Failure instance" in {
+    mValidation.failure.getOrModify(123.success) ==== 123.success.left
+    mValidation.failure.getOrModify("abc".failure) ==== "abc".right
+
+    mValidation.failure.getOption("abc".failure) ==== Some("abc")
+    mValidation.failure.getOption(123.success) ==== None
+
+    mValidation.failure.reverseGet(123) ==== 123.failure
+
+    mValidation.failure.set('a')(1.failure) ==== 'a'.failure
+    mValidation.failure.set(2)("e".success) ==== "e".success
+
+    mValidation.failure[Int, String, Double].modify(_ + 2.34D)(10.failure) ==== 12.34D.failure
+    mValidation.failure[String, String, Int].modify(_.toInt)("abc".success) ==== "abc".success
+  }
+}

--- a/example/src/test/scala/monocle/std/ValidationExample.scala
+++ b/example/src/test/scala/monocle/std/ValidationExample.scala
@@ -13,7 +13,7 @@ class ValidationExample extends Spec {
     mValidation.success.getOption("abc".failure) ==== None
 
     mValidation.success.set('a')(123.success) ==== 'a'.success
-    mValidation.success.set(123)("abc".failure) ==== "e".failure
+    mValidation.success.set(123)("abc".failure) ==== "abc".failure
   }
 
   "failure defines a Prism that can modify the underlying value of a Failure instance" in {

--- a/example/src/test/scala/monocle/std/ValidationExample.scala
+++ b/example/src/test/scala/monocle/std/ValidationExample.scala
@@ -8,34 +8,15 @@ import scalaz.syntax.validation._
 import scalaz.syntax.either._
 
 class ValidationExample extends Spec {
-  "success defines a Prism that can get, set or modify the underlying value of a Success instance" in {
-    mValidation.success.getOrModify(123.success) ==== 123.right
-    mValidation.success.getOrModify("abc".failure) ==== "abc".failure.left
-
+  "success defines a Prism that can get or set the underlying value of a Success instance" in {
     mValidation.success.getOption(123.success) ==== Some(123)
     mValidation.success.getOption("abc".failure) ==== None
 
-    mValidation.success.reverseGet(123) ==== 123.success
-
     mValidation.success.set('a')(123.success) ==== 'a'.success
-    mValidation.success.set(123)("e".failure) ==== "e".failure
-
-    mValidation.success[String, Int, Double].modify(_ + 2.34D)(10.success) ==== 12.34D.success
-    mValidation.success[String, String, Int].modify(_.toInt)("abc".failure) ==== "abc".failure
+    mValidation.success.set(123)("abc".failure) ==== "e".failure
   }
 
-  "failure defines a Prism that can get, set or modify the underlying value of a Failure instance" in {
-    mValidation.failure.getOrModify(123.success) ==== 123.success.left
-    mValidation.failure.getOrModify("abc".failure) ==== "abc".right
-
-    mValidation.failure.getOption("abc".failure) ==== Some("abc")
-    mValidation.failure.getOption(123.success) ==== None
-
-    mValidation.failure.reverseGet(123) ==== 123.failure
-
-    mValidation.failure.set('a')(1.failure) ==== 'a'.failure
-    mValidation.failure.set(2)("e".success) ==== "e".success
-
+  "failure defines a Prism that can modify the underlying value of a Failure instance" in {
     mValidation.failure[Int, String, Double].modify(_ + 2.34D)(10.failure) ==== 12.34D.failure
     mValidation.failure[String, String, Int].modify(_.toInt)("abc".success) ==== "abc".success
   }

--- a/test/src/test/scala/monocle/TestUtil.scala
+++ b/test/src/test/scala/monocle/TestUtil.scala
@@ -93,6 +93,9 @@ object TestUtil {
   implicit def disjunctionArbitrary[A: Arbitrary, B: Arbitrary]: Arbitrary[A \/ B] =
     Arbitrary(arbitrary[Either[A, B]] map \/.fromEither)
 
+  implicit def validationArbitrary[A: Arbitrary, B: Arbitrary]: Arbitrary[Validation[A, B]] =
+    Arbitrary(arbitrary[A \/ B].map(_.validation))
+
   implicit def theseArbitrary[A: Arbitrary, B: Arbitrary]: Arbitrary[A \&/ B] =
     Arbitrary(Gen.oneOf(
       arbitrary[A].map(This(_)),

--- a/test/src/test/scala/monocle/std/ValidationSpec.scala
+++ b/test/src/test/scala/monocle/std/ValidationSpec.scala
@@ -1,0 +1,11 @@
+package monocle.std
+
+import monocle.TestUtil._
+import monocle.law.{IsoLaws, PrismLaws}
+import org.specs2.scalaz.Spec
+
+class ValidationSpec extends Spec {
+  checkAll("Validation is isomorphic to Disjunction", IsoLaws(monocle.std.validation.disjunctionIso[String, String, Int, Int]))
+  checkAll("success", PrismLaws(monocle.std.validation.success[Int, String, String]))
+  checkAll("failure", PrismLaws(monocle.std.validation.failure[Int, String, Int]))
+}


### PR DESCRIPTION
This PR contains optics for scalaz.Validation, (hopefully) completing the work begun in https://github.com/julien-truffaut/Monocle/pull/178:

- the ValidationFunctions provides success and failure implementations, along with a Disjunction Iso implementation
- get, set and modify examples provided in the examples project
- scalacheck properties exercising Prism and Iso Laws defined in the test project.

Happy to add any other optics that might be useful/relevant here.