### PR TITLE
GenIso for objects

### DIFF
--- a/macro/src/main/scala-2.10/monocle.macros.internal/MacrosCompatibility.scala
+++ b/macro/src/main/scala-2.10/monocle.macros.internal/MacrosCompatibility.scala
@@ -1,5 +1,7 @@
 package monocle.macros.internal
 
+import scala.reflect.macros.TreeBuilder
+
 trait MacrosCompatibility {
   type Context = scala.reflect.macros.Context
 
@@ -26,4 +28,7 @@ trait MacrosCompatibility {
 
   def companionTpe(c: Context)(tpe: c.universe.Type): c.universe.Symbol =
     tpe.typeSymbol.companionSymbol
+
+  def makeAttributedQualifier(c: Context)(tree: TreeBuilder, tpe: c.universe.Type): c.universe.Tree =
+    tree.mkAttributedQualifier(tpe.asInstanceOf[tree.global.Type]).asInstanceOf[c.universe.Tree]
 }

--- a/macro/src/main/scala-2.11/monocle.macros.internal/MacrosCompatibility.scala
+++ b/macro/src/main/scala-2.11/monocle.macros.internal/MacrosCompatibility.scala
@@ -1,5 +1,7 @@
 package monocle.macros.internal
 
+import scala.reflect.internal.TreeGen
+
 trait MacrosCompatibility {
   type Context = scala.reflect.macros.blackbox.Context
 
@@ -26,4 +28,7 @@ trait MacrosCompatibility {
 
   def companionTpe(c: Context)(tpe: c.universe.Type): c.universe.Symbol =
     tpe.typeSymbol.companion
+
+  def makeAttributedQualifier(c: Context)(tree: TreeGen, tpe: c.universe.Type): c.universe.Tree =
+    tree.mkAttributedQualifier(tpe.asInstanceOf[tree.global.Type]).asInstanceOf[c.universe.Tree]
 }

--- a/macro/src/main/scala/monocle/macros/GenIso.scala
+++ b/macro/src/main/scala/monocle/macros/GenIso.scala
@@ -65,7 +65,7 @@ private object GenIsoImpl extends MacrosCompatibility {
     if (!sTpe.typeSymbol.isModuleClass)
        c.abort(c.enclosingPosition, s"${sTpe} needs to be an object to generate an Iso[${sTpe}, Unit]")
 
-    val obj = table.gen.mkAttributedQualifier(sTpe.asInstanceOf[table.Type]).asInstanceOf[Tree]
+    val obj = makeAttributedQualifier(c)(table.gen, sTpe)
 
     c.Expr[Iso[S, Unit]](q"""
       monocle.Iso[${sTpe}, Unit](Function.const(()))(Function.const(${obj}))

--- a/test/src/test/scala/monocle/IsoSpec.scala
+++ b/test/src/test/scala/monocle/IsoSpec.scala
@@ -2,12 +2,11 @@ package monocle
 
 import monocle.law.discipline._
 import monocle.macros.GenIso
-import org.scalacheck.Arbitrary
+import org.scalacheck.{Arbitrary, Gen}
 import org.scalacheck.Arbitrary._
 
 import scalaz.std.anyVal._
 import scalaz.{Category, Compose, Equal, Split}
-
 
 class IsoSpec extends MonocleSuite {
 
@@ -17,10 +16,17 @@ class IsoSpec extends MonocleSuite {
 
   implicit val intWrapperEq = Equal.equalA[IntWrapper]
 
+  case object AnObject
+
+  implicit val anObjectGen: Arbitrary[AnObject.type] = Arbitrary(Gen.const(AnObject))
+
+  implicit val anObjectEq = Equal.equalA[AnObject.type]
+
   val iso = Iso[IntWrapper, Int](_.i)(IntWrapper.apply)
 
   checkAll("apply Iso", IsoTests(iso))
   checkAll("GenIso", IsoTests(GenIso[IntWrapper, Int]))
+  checkAll("GenIso.obj", IsoTests(GenIso.obj[AnObject.type]))
 
   checkAll("Iso id", IsoTests(Iso.id[Int]))
 

--- a/test/src/test/scala/other/MacroOutSideMonocleSpec.scala
+++ b/test/src/test/scala/other/MacroOutSideMonocleSpec.scala
@@ -12,22 +12,27 @@ class MacroOutSideMonocleSpec extends MonocleSuite {
 
   case class Example(i: Int)
 
+  case object ExampleObject
+
   sealed trait Foo
   case class Bar1(s: String) extends Foo
   case class Bar2(i: Int) extends Foo
 
   implicit val exampleArb: Arbitrary[Example] = Arbitrary(arbitrary[Int].map(Example.apply))
+  implicit val exampleObjArb: Arbitrary[ExampleObject.type] = Arbitrary(Gen.const(ExampleObject))
   implicit val bar1Arb: Arbitrary[Bar1] = Arbitrary(arbitrary[String].map(Bar1.apply))
   implicit val bar2Arb: Arbitrary[Bar2] = Arbitrary(arbitrary[Int].map(Bar2.apply))
   implicit val fooArb: Arbitrary[Foo] = Arbitrary(Gen.oneOf(arbitrary[Bar1], arbitrary[Bar2]))
 
   implicit val exampleEq: Equal[Example] = Equal.equalA[Example]
+  implicit val exampleObjEq: Equal[ExampleObject.type] = Equal.equalA[ExampleObject.type]
   implicit val bar1Eq: Equal[Bar1] = Equal.equalA[Bar1]
   implicit val fooEq: Equal[Foo] = Equal.equalA[Foo]
 
 
-  checkAll("GenIso"  , IsoTests(GenIso[Example, Int]))
-  checkAll("GenLens" , LensTests(GenLens[Example](_.i)))
-  checkAll("GenPrism", PrismTests(GenPrism[Foo, Bar1]))
+  checkAll("GenIso"     , IsoTests(GenIso[Example, Int]))
+  checkAll("GenIso.obj" , IsoTests(GenIso.obj[ExampleObject.type]))
+  checkAll("GenLens"    , LensTests(GenLens[Example](_.i)))
+  checkAll("GenPrism"   , PrismTests(GenPrism[Foo, Bar1]))
 
 }


### PR DESCRIPTION
Many thanks to @retronym for helping me out with a Scala 2.10/2.11 issue regarding prefixes, see https://gist.github.com/retronym/4752d7c1dba6fb837ae5 (reproduced below)

```scala
% tail sandbox/{macro,client}.scala
==> sandbox/macro.scala <==
object Macro {
  def m[S]: () => S = macro impl[S]
 
  def impl[S : c.WeakTypeTag](c: Context): c.Expr[() => S] = {
    import c.universe._
    val sym = weakTypeOf[S].typeSymbol.asClass.module
 
    reify(() => c.Expr[S](Ident(sym)).splice)
  }
}
 
==> sandbox/client.scala <==
class Client {
  object O
  Macro.m[O.type]
}
% (export V=v2.11.6; scalac-hash $V sandbox/macro.scala && scalac-hash $V sandbox/client.scala)
warning: there was one deprecation warning; re-run with -deprecation for details
one warning found
 
% (export V=v2.10.4; scalac-hash $V sandbox/macro.scala && scalac-hash $V sandbox/client.scala)
sandbox/client.scala:3: error: type mismatch;
 found   : O.type
 required: Client.this.O.type
  Macro.m[O.type]
         ^
one error found
```