### PR TITLE
renamed getOrModify to matching

### DIFF
--- a/core/src/main/scala/monocle/Iso.scala
+++ b/core/src/main/scala/monocle/Iso.scala
@@ -200,7 +200,7 @@ abstract class PIso[S, T, A, B] extends Serializable { self =>
   /** view a [[PIso]] as a [[POptional]] */
   @inline final def asOptional: POptional[S, T, A, B] =
     new POptional[S, T, A, B]{
-      def getOrModify(s: S): T \/ A =
+      def matching(s: S): T \/ A =
         \/.right(get(s))
 
       def set(b: B): S => T =
@@ -219,7 +219,7 @@ abstract class PIso[S, T, A, B] extends Serializable { self =>
   /** view a [[PIso]] as a [[PPrism]] */
   @inline final def asPrism: PPrism[S, T, A, B] =
     new PPrism[S, T, A, B]{
-      def getOrModify(s: S): T \/ A =
+      def matching(s: S): T \/ A =
         \/.right(get(s))
 
       def reverseGet(b: B): T =

--- a/core/src/main/scala/monocle/Lens.scala
+++ b/core/src/main/scala/monocle/Lens.scala
@@ -185,7 +185,7 @@ abstract class PLens[S, T, A, B] extends Serializable { self =>
   /** view a [[PLens]] as an [[POptional]] */
   @inline final def asOptional: POptional[S, T, A, B] =
     new POptional[S, T, A, B] {
-      def getOrModify(s: S): T \/ A =
+      def matching(s: S): T \/ A =
         \/.right(get(s))
 
       def set(b: B): S => T =

--- a/core/src/main/scala/monocle/law/OptionalLaws.scala
+++ b/core/src/main/scala/monocle/law/OptionalLaws.scala
@@ -9,7 +9,7 @@ class OptionalLaws[S, A](optional: Optional[S, A]) {
   import IsEq.syntax
 
   def getOptionSet(s: S): IsEq[S] =
-    optional.getOrModify(s).fold(identity, optional.set(_)(s)) <==> s
+    optional.matching(s).fold(identity, optional.set(_)(s)) <==> s
 
   def setGetOption(s: S, a: A): IsEq[Option[A]] =
     optional.getOption(optional.set(a)(s)) <==> optional.getOption(s).map(_ => a)

--- a/core/src/main/scala/monocle/law/PrismLaws.scala
+++ b/core/src/main/scala/monocle/law/PrismLaws.scala
@@ -9,7 +9,7 @@ class PrismLaws[S, A](prism: Prism[S, A]) {
   import IsEq.syntax
 
   def partialRoundTripOneWay(s: S): IsEq[S] =
-    prism.getOrModify(s).fold(identity, prism.reverseGet) <==> s
+    prism.matching(s).fold(identity, prism.reverseGet) <==> s
   
   def roundTripOtherWay(a: A): IsEq[Option[A]] =
     prism.getOption(prism.reverseGet(a)) <==> Some(a)

--- a/macro/src/main/scala/monocle/macros/GenPrism.scala
+++ b/macro/src/main/scala/monocle/macros/GenPrism.scala
@@ -3,9 +3,6 @@ package monocle.macros
 import monocle.Prism
 import monocle.macros.internal.MacrosCompatibility
 
-
-
-
 object GenPrism {
   /** generate a [[Prism]] between `S` and a subtype `A` of `S` */
   def apply[S, A <: S]: Prism[S, A] = macro GenPrismImpl.genPrism_impl[S, A]
@@ -23,7 +20,7 @@ private object GenPrismImpl extends MacrosCompatibility {
       import scalaz.{\/, \/-, -\/}
 
       new Prism[$sTpe, $aTpe]{
-        def getOrModify(s: $sTpe): $sTpe \/ $aTpe =
+        def matching(s: $sTpe): $sTpe \/ $aTpe =
           if(s.isInstanceOf[$aTpe]) \/-(s.asInstanceOf[$aTpe])
           else -\/(s)
 


### PR DESCRIPTION
I never liked the name `getOrModify` but I couldn't find the equivalent in haskell lens.

I completely missed it: https://hackage.haskell.org/package/lens-4.12.3/docs/src/Control-Lens-Prism.html#matching