### PR TITLE
remove kind projector (limited usage + intellij issue)

### DIFF
--- a/bench/src/main/scala/monocle/bench/MonocleTraversalBench.scala
+++ b/bench/src/main/scala/monocle/bench/MonocleTraversalBench.scala
@@ -10,7 +10,7 @@ import scalaz.IMap
 class MonocleTraversalBench {
 
   val point3Traversal = Traversal.apply3[Point3, Int](_.x, _.y, _.z)((x, y, z, _) => Point3(x, y, z))
-  val iMapTraversal = PTraversal.fromTraverse[IMap[Int, ?], Int, Int]
+  val iMapTraversal = PTraversal.fromTraverse[({type λ[α] = IMap[Int, α]})#λ, Int, Int]
 
 
   @Benchmark def caseClassGetAll() = point3Traversal.getAll(p)

--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,6 @@ lazy val scalatest  = "org.scalatest"   %% "scalatest"   % "2.2.4"  % "test"
 
 lazy val macroVersion = "2.0.1"
 lazy val paradisePlugin = compilerPlugin("org.scalamacros" %  "paradise"       % macroVersion cross CrossVersion.full)
-lazy val kindProjector  = compilerPlugin("org.spire-math"  %% "kind-projector" % "0.6.0")
 
 def mimaSettings(module: String): Seq[Setting[_]] = mimaDefaultSettings ++ Seq(
   previousArtifact := Some("com.github.julien-truffaut" %  (s"monocle-${module}_2.11") % "1.1.0")
@@ -56,7 +55,7 @@ lazy val core = project
   .settings(moduleName := "monocle-core")
   .settings(monocleSettings)
   .settings(mimaSettings("core"))
-  .settings(libraryDependencies := Seq(scalaz, compilerPlugin(kindProjector)))
+  .settings(libraryDependencies := Seq(scalaz))
 
 lazy val generic = project.dependsOn(core)
   .settings(moduleName := "monocle-generic")
@@ -99,15 +98,12 @@ lazy val test = project.dependsOn(core, generic, macros, law, state)
     libraryDependencies ++= Seq(scalaz, shapeless, scalatest, compilerPlugin(paradisePlugin))
   )
 
-lazy val bench = project
+lazy val bench = project.dependsOn(core, macros)
   .settings(moduleName := "monocle-bench")
   .settings(monocleSettings)
   .settings(noPublishSettings)
   .settings(libraryDependencies ++= Seq(
-    "com.github.julien-truffaut" %%  "monocle-core"  % "1.2.0-SNAPSHOT",
-    "com.github.julien-truffaut" %%  "monocle-macro" % "1.2.0-SNAPSHOT",
     shapeless,
-    compilerPlugin(kindProjector),
     compilerPlugin(paradisePlugin)
   )).enablePlugins(JmhPlugin)
 
@@ -129,7 +125,7 @@ lazy val docs = project.dependsOn(core, example)
   .settings(docSettings)
   .settings(tutSettings)
   .settings(
-    libraryDependencies ++= Seq(scalaz, shapeless, compilerPlugin(kindProjector), compilerPlugin(paradisePlugin))
+    libraryDependencies ++= Seq(scalaz, shapeless, compilerPlugin(paradisePlugin))
   )
 
 

--- a/core/src/main/scala/monocle/Traversal.scala
+++ b/core/src/main/scala/monocle/Traversal.scala
@@ -38,7 +38,7 @@ abstract class PTraversal[S, T, A, B] extends Serializable { self =>
 
   /** map each target to a Monoid and combine the results */
   @inline final def foldMap[M: Monoid](f: A => M)(s: S): M =
-    modifyF[Const[M, ?]](a => Const(f(a)))(s).getConst
+    modifyF[({type λ[α] = Const[M, α]})#λ](a => Const(f(a)))(s).getConst
 
   /** combine all targets using a target's Monoid */
   @inline final def fold(s: S)(implicit ev: Monoid[A]): A =

--- a/core/src/main/scala/monocle/Traversal.scala
+++ b/core/src/main/scala/monocle/Traversal.scala
@@ -38,6 +38,7 @@ abstract class PTraversal[S, T, A, B] extends Serializable { self =>
 
   /** map each target to a Monoid and combine the results */
   @inline final def foldMap[M: Monoid](f: A => M)(s: S): M =
+    // equivalent to modifyF[Const[M, ?]](a => Const(f(a)))(s).getConst
     modifyF[({type λ[α] = Const[M, α]})#λ](a => Const(f(a)))(s).getConst
 
   /** combine all targets using a target's Monoid */

--- a/core/src/main/scala/monocle/std/IMap.scala
+++ b/core/src/main/scala/monocle/std/IMap.scala
@@ -19,7 +19,7 @@ trait IMapOptics {
     def at(i: K) = Lens{m: ==>>[K, V] => m.lookup(i)}(optV => map => optV.fold(map - i)(v => map + (i -> v)))
   }
 
-  implicit def iMapEach[K, V]: Each[K ==>> V, V] = Each.traverseEach[==>>[K, ?], V]
+  implicit def iMapEach[K, V]: Each[K ==>> V, V] = Each.traverseEach[({type λ[α] = K ==>> α})#λ, V]
 
   implicit def iMapIndex[K: Order, V]: Index[K ==>> V, K, V] = Index.atIndex
 

--- a/core/src/main/scala/monocle/std/Map.scala
+++ b/core/src/main/scala/monocle/std/Map.scala
@@ -20,7 +20,7 @@ trait MapOptics {
     def at(i: K) = Lens{m: Map[K, V] => m.get(i)}(optV => map => optV.fold(map - i)(v => map + (i -> v)))
   }
 
-  implicit def mapEach[K, V]: Each[Map[K, V], V] = Each.traverseEach[Map[K, ?], V]
+  implicit def mapEach[K, V]: Each[Map[K, V], V] = Each.traverseEach[({type λ[α] = Map[K, α]})#λ, V]
 
   implicit def mapIndex[K, V]: Index[Map[K, V], K  , V] = Index.atIndex
 


### PR DESCRIPTION
This is a contentious PR.

Intellij 14 / 15 CE does not seem to understand kind projector any more. I believe it started since we migrated from `Build.scala` to `build.sbt` but I cannot tell for sure. Since it is blocking or at least annoying potential contributor (see https://groups.google.com/forum/#!topic/scala-monocle/2MEXvY4k5cE) I would rather remove `kind projector` for the moment.