### PR TITLE
Fix typo in lens.md

### DIFF
--- a/docs/src/main/tut/lens.md
+++ b/docs/src/main/tut/lens.md
@@ -67,7 +67,7 @@ val john = Person("John", 20, address)
 ```
 
 ```scala
-val _address = Lens[Person, Address](_.address)(p => a => p.copy(address = a)) 
+val _address = Lens[Person, Address](_.address)(a => p => p.copy(address = a)) 
 
 (_address composeLens _streetNumber).get(john)
 (_address composeLens _streetNumber).set(2)(john)


### PR DESCRIPTION
`Lens[S, A].apply` requires `A => S => S` as the second argument

So, `(p => a => p.copy...)` should be `(a => p => p.copy...)`