### PR TITLE
Fix #114: generate polymorphic lenses

### DIFF
--- a/example/src/test/scala/monocle/LensExample.scala
+++ b/example/src/test/scala/monocle/LensExample.scala
@@ -94,4 +94,8 @@ class LensPolyExample extends MonocleSuite {
     Foo.q.modify((_: Map[(Int,Symbol),Double]).updated((0,'Buy), -2.0))(candyTrade) shouldEqual changedTrade
   }
 
+  test("@Lenses generates polymorphic lenses") {
+    val changedTrade = candyTrade.copy(q = candyTrade.q.map{case (x, y) => (x.swap, y)})
+    Foo.q.modify((_: Map[(Int, Symbol), Double]).map{case (x, y) => (x.swap, y)})(candyTrade) shouldEqual changedTrade
+  }
 }

--- a/example/src/test/scala/monocle/LensExample.scala
+++ b/example/src/test/scala/monocle/LensExample.scala
@@ -1,6 +1,6 @@
 package monocle
 
-import monocle.macros.{GenLens, Lenses}
+import monocle.macros.{GenLens, Lenses, PLenses}
 import shapeless.test.illTyped
 
 class LensMonoExample extends MonocleSuite {
@@ -69,7 +69,7 @@ class LensMonoExample extends MonocleSuite {
 
 class LensPolyExample extends MonocleSuite {
 
-  @Lenses case class Foo[A,B](q: Map[(A,B),Double], default: Double)
+  @PLenses case class Foo[A,B](q: Map[(A,B),Double], default: Double)
 
   object Manual { // Lens created manually (i.e. without macro)
   def q[A,B] = Lens((_: Foo[A,B]).q)(q => f => f.copy(q = q))
@@ -94,8 +94,16 @@ class LensPolyExample extends MonocleSuite {
     Foo.q.modify((_: Map[(Int,Symbol),Double]).updated((0,'Buy), -2.0))(candyTrade) shouldEqual changedTrade
   }
 
-  test("@Lenses generates polymorphic lenses") {
+  test("@PLenses generates polymorphic lenses") {
     val changedTrade = candyTrade.copy(q = candyTrade.q.map{case (x, y) => (x.swap, y)})
-    Foo.q.modify((_: Map[(Int, Symbol), Double]).map{case (x, y) => (x.swap, y)})(candyTrade) shouldEqual changedTrade
+    Foo.q.modify((_: Map[(Int, Symbol), Double]).map {case (x, y) => (x.swap, y)})(candyTrade) shouldEqual changedTrade
+  }
+
+  @PLenses("_") case class Cat(age: Int)
+
+  val alpha = Cat(2)
+
+  test("@PLenses takes an optional prefix string") {
+    Cat._age.get(alpha) shouldEqual 2
   }
 }

--- a/macro/src/main/scala/monocle/macros/Lenses.scala
+++ b/macro/src/main/scala/monocle/macros/Lenses.scala
@@ -3,16 +3,24 @@ package monocle.macros
 import scala.reflect.macros.blackbox
 
 class Lenses(prefix: String = "") extends scala.annotation.StaticAnnotation {
-  def macroTransform(annottees: Any*): Any = macro LensesImpl.annotationMacro
+  def macroTransform(annottees: Any*): Any = macro LensesImpl.lensesAnnotationMacro
+}
+
+class PLenses(prefix: String = "") extends scala.annotation.StaticAnnotation {
+  def macroTransform(annottees: Any*): Any = macro LensesImpl.plensesAnnotationMacro
 }
 
 @macrocompat.bundle
 private[macros] class LensesImpl(val c: blackbox.Context) {
 
-  def annotationMacro(annottees: c.Expr[Any]*): c.Expr[Any] = {
+  def lensesAnnotationMacro(annottees: c.Expr[Any]*): c.Expr[Any] = annotationMacro(annottees, poly = false)
+
+  def plensesAnnotationMacro(annottees: c.Expr[Any]*): c.Expr[Any] = annotationMacro(annottees, poly = true)
+
+  def annotationMacro(annottees: Seq[c.Expr[Any]], poly: Boolean): c.Expr[Any] = {
     import c.universe._
 
-    val LensesTpe = TypeName("Lenses")
+    val LensesTpe = TypeName(if (poly) "PLenses" else "Lenses")
     val prefix = c.macroApplication match {
       case Apply(Select(Apply(Select(New(Ident(LensesTpe)), t), args), _), _) if t == termNames.CONSTRUCTOR => args match {
         case Literal(Constant(s: String)) :: Nil => s
@@ -21,25 +29,43 @@ private[macros] class LensesImpl(val c: blackbox.Context) {
       case _ => ""
     }
 
-    def lenses(tpname: TypeName, tparams: List[TypeDef], paramss: List[List[ValDef]]): List[Tree] = {
-      val params1 = paramss.head
+    def monolenses(tpname: TypeName, params: List[ValDef]): List[Tree] = params.map { param =>
+      val lensName = TermName(prefix + param.name.decodedName)
+      q"""val $lensName =
+        monocle.macros.internal.Macro.mkLens[$tpname, $tpname, ${param.tpt}, ${param.tpt}](${param.name.toString})"""
+    }
 
-      // number of fields in which each tparam is used
-      val tparamsUsages: Map[TypeName, Int] = params1.foldLeft(tparams.map { _.name -> 0 }.toMap){ (acc, param) =>
-        val typeNames = param.collect{ case Ident(tn@TypeName(_)) => tn }.toSet
-        typeNames.foldLeft(acc){ (map, key) => map.get(key).fold(map){ value => map.updated(key, value + 1) }}
+    def lenses(tpname: TypeName, tparams: List[TypeDef], params: List[ValDef]): List[Tree] = {
+      if (tparams.isEmpty) {
+        monolenses(tpname, params)
+      } else {
+        params.map { param =>
+          val lensName = TermName(prefix + param.name.decodedName)
+          val q"x: $s" = q"x: $tpname[..${tparams.map(_.name)}]"
+          val q"x: $a" = q"x: ${param.tpt}"
+          q"""def $lensName[..$tparams] =
+            monocle.macros.internal.Macro.mkLens[$s, $s, $a, $a](${param.name.toString})"""
+        }
       }
+    }
 
-      val groupedTpnames: Map[Int, Set[TypeName]] =
-        tparamsUsages.toList.groupBy(_._2).map{ case (n, tps) => (n, tps.map(_._1).toSet) }
-      val phantomTpnames = groupedTpnames.getOrElse(0, Set.empty)
-      val singleFieldTpnames = groupedTpnames.getOrElse(1, Set.empty)
+    def plenses(tpname: TypeName, tparams: List[TypeDef], params: List[ValDef]): List[Tree] = {
+      if (tparams.isEmpty) {
+        monolenses(tpname, params)
+      } else {
+        // number of fields in which each tparam is used
+        val tparamsUsages: Map[TypeName, Int] = params.foldLeft(tparams.map { _.name -> 0 }.toMap){ (acc, param) =>
+          val typeNames = param.collect{ case Ident(tn@TypeName(_)) => tn }.toSet
+          typeNames.foldLeft(acc){ (map, key) => map.get(key).fold(map){ value => map.updated(key, value + 1) }}
+        }
 
-      params1 map { param =>
-        val lensName = TermName(prefix + param.name.decodedName)
-        if (tparams.isEmpty)
-          q"""val $lensName = monocle.macros.internal.Macro.mkLens[$tpname, $tpname, ${param.tpt}, ${param.tpt}](${param.name.toString})"""
-        else {
+        val groupedTpnames: Map[Int, Set[TypeName]] =
+          tparamsUsages.toList.groupBy(_._2).map{ case (n, tps) => (n, tps.map(_._1).toSet) }
+        val phantomTpnames = groupedTpnames.getOrElse(0, Set.empty)
+        val singleFieldTpnames = groupedTpnames.getOrElse(1, Set.empty)
+
+        params.map { param =>
+          val lensName = TermName(prefix + param.name.decodedName)
           val tpnames = param.collect{ case Ident(tn@TypeName(_)) => tn }.toSet
           val tpnamesToChange = tpnames.intersect(singleFieldTpnames) ++ phantomTpnames
           val tpnamesMap = tpnamesToChange.foldLeft((tparams.map(_.name).toSet ++ tpnames).map(x => (x, x)).toMap){ (acc, tpname) =>
@@ -67,6 +93,8 @@ private[macros] class LensesImpl(val c: blackbox.Context) {
       }
     }
 
+    val lensDefs = if (poly) plenses _ else lenses _
+
     val result = annottees map (_.tree) match {
       case (classDef @ q"$mods class $tpname[..$tparams] $ctorMods(...$paramss) extends { ..$earlydefns } with ..$parents { $self => ..$stats }")
         :: Nil if mods.hasFlag(Flag.CASE) =>
@@ -74,7 +102,7 @@ private[macros] class LensesImpl(val c: blackbox.Context) {
         q"""
          $classDef
          object $name {
-           ..${lenses(tpname, tparams, paramss)}
+           ..${lensDefs(tpname, tparams, paramss.head)}
          }
          """
       case (classDef @ q"$mods class $tpname[..$tparams] $ctorMods(...$paramss) extends { ..$earlydefns } with ..$parents { $self => ..$stats }")
@@ -83,7 +111,7 @@ private[macros] class LensesImpl(val c: blackbox.Context) {
         q"""
          $classDef
          object $objName extends { ..$objEarlyDefs} with ..$objParents { $objSelf =>
-           ..${lenses(tpname, tparams, paramss)}
+           ..${lensDefs(tpname, tparams, paramss.head)}
            ..$objDefs
          }
          """


### PR DESCRIPTION
Here, `@Lenses` is changed to generate polymorphic lenses for case classes with type parameters. Generated lenses are polymorphic in types that are used by corresponding field (and only by it) and types that aren't used by any field. For example:
```
case class Foo[A, B, C](x: (A, B), y: B => Double)
```
will have the following lenses generated:
```
def x[A, B, C, A$, C$] = new PLens[Foo[A, B, C], Foo[A$, B, C$], (A, B), (A$, B)]{ … }
def y[A, B, C, C$] = new PLens[Foo[A, B, C], Foo[A, B, C$], B => Double, B => Double]{ … }
```