### PR TITLE
Use Vector.updated for efficient, persistent indexed vector updates

### DIFF
--- a/core/src/main/scala/monocle/std/Vector.scala
+++ b/core/src/main/scala/monocle/std/Vector.scala
@@ -19,13 +19,10 @@ trait VectorOptics {
   implicit def vectorEach[A]: Each[Vector[A], A] = Each.traverseEach[Vector, A]
 
   implicit def vectorIndex[A]: Index[Vector[A], Int, A] = new Index[Vector[A], Int, A] {
-    def index(i: Int) = Optional[Vector[A], A](
-      v      => if(i < 0) None else \/.fromTryCatchNonFatal(v.apply(i)).toOption)(
-      a => v => v.zipWithIndex.traverse[Id, A]{
-        case (_    , index) if index == i => a
-        case (value, index)               => value
-      }
-    )
+    def index(i: Int) =
+      Optional[Vector[A], A](v =>
+        \/.fromTryCatchNonFatal(v(i)).toOption)(a => v =>
+        \/.fromTryCatchNonFatal(v.updated(i, a)).getOrElse(v))
   }
 
   implicit def vectorFilterIndex[A]: FilterIndex[Vector[A], Int, A] =


### PR DESCRIPTION
Current implementation of indexed updates for Vector seems to be doing a full traversal and copy, which is O(n) or worse and also bypasses the nice persistent sharing properties of Vector. This small patch uses Vector.updated, which enables structural sharing and much lower time complexity.