### PR TITLE
WIP - Cofree Optics

### DIFF
--- a/core/src/main/scala/monocle/std/All.scala
+++ b/core/src/main/scala/monocle/std/All.scala
@@ -36,3 +36,4 @@ trait StdInstances
   with    OneAndOptics
   with    TreeOptics
   with    ValidationOptics
+  with    CofreeOptics

--- a/core/src/main/scala/monocle/std/All.scala
+++ b/core/src/main/scala/monocle/std/All.scala
@@ -26,6 +26,7 @@ trait StdInstances
   with    Tuple6Optics
   with    VectorOptics
   // Scalaz Instances
+  with    CofreeOptics
   with    Either3Optics
   with    DisjunctionOptics
   with    TheseOptics
@@ -36,4 +37,3 @@ trait StdInstances
   with    OneAndOptics
   with    TreeOptics
   with    ValidationOptics
-  with    CofreeOptics

--- a/core/src/main/scala/monocle/std/Cofree.scala
+++ b/core/src/main/scala/monocle/std/Cofree.scala
@@ -1,0 +1,66 @@
+package monocle.std
+
+import monocle.function._
+import monocle.{Lens, PIso, Iso, Optional, PTraversal, Traversal}
+
+import scalaz.Cofree._
+import scalaz.{Cofree, Free, Applicative, Traverse, OneAnd, Tree}
+
+object cofree extends CofreeOptics
+
+trait CofreeOptics {
+
+  private def toStream[A](c: Cofree[Option, A]): Stream[A] =
+    c.head #:: c.tail.fold(Stream.empty[A])(toStream[A])
+
+  private def fromStream[A, B](z: A, c: Stream[A]): Cofree[Option, A] = c match {
+    case head #:: tail => Cofree.delay(z, Some(fromStream(head, tail)))
+    case _ => Cofree(z, None: Option[Cofree[Option, A]])
+  }
+
+  /** Polymorphic isomorphism between `Cofree[Option, _]` and `OneAnd[Stream, _]` */
+  def pCofreeToStream[A, B]: PIso[Cofree[Option, A], Cofree[Option, B],
+                                  OneAnd[Stream, A], OneAnd[Stream, B]] =
+    PIso[Cofree[Option, A], Cofree[Option, B], OneAnd[Stream, A], OneAnd[Stream, B]](
+      (c: Cofree[Option, A]) => OneAnd[Stream, A](c.head, toStream(c))
+    ){ case OneAnd(head, tail) => fromStream(head, tail) }
+
+  /** [[Iso]] variant of [[pCofreeToStream]]  */
+  def cofreeToStream[A]: Iso[Cofree[Option, A], OneAnd[Stream, A]] =
+    pCofreeToStream[A, A]
+
+
+  private def toTree[A](c: Cofree[Stream, A]): Tree[A] =
+    Tree.node(c.head, c.tail.map(toTree[A]))
+
+  private def fromTree[A](c: Tree[A]): Cofree[Stream, A] =
+    Cofree.delay(c.rootLabel, c.subForest.map(fromTree[A]))
+
+  /** Polymorphic isomorphism between `Cofree[Stream, _]` and `Tree` */
+  def pCofreeToTree[A, B]: PIso[Cofree[Stream, A], Cofree[Stream, B],
+                                Tree[A], Tree[B]] =
+    PIso[Cofree[Stream, A], Cofree[Stream, B], Tree[A], Tree[B]](toTree[A])(fromTree[B])
+
+  /** [[Iso]] variant of [[pCofreeToTree]] */
+  def cofreeToTree[A]: Iso[Cofree[Stream, A], Tree[A]] =
+    pCofreeToTree[A, A]
+
+
+  /** Evidence that cofree structures can be split up into a `head` and a `tail` */
+  implicit def cofreeCons1[S[_], A]: Cons1[Cofree[S, A], A, S[Cofree[S, A]]] =
+    new Cons1[Cofree[S, A], A, S[Cofree[S, A]]] {
+
+      def cons1: Iso[Cofree[S, A], (A, S[Cofree[S, A]])]  =
+        Iso((c: Cofree[S, A]) => (c.head, c.tail)){ case (h, t) => Cofree(h, t) }
+
+      /** Overridden to prevent forcing evaluation of the `tail` when we're only
+        * interested in using the `head` */
+      override def head: Lens[Cofree[S, A], A] =
+        Lens((c: Cofree[S, A]) => c.head)(h => c => Cofree.delay(h, c.tail))
+    }
+
+
+  /** Trivial [[Each]] instance due to `Cofree S` being traversable when `S` is */
+  implicit def cofreeEach[S[_] : Traverse, A]: Each[Cofree[S, A], A] =
+    Each.traverseEach[({type L[X] = Cofree[S, X]})#L, A]
+}

--- a/test/src/test/scala/monocle/TestInstances.scala
+++ b/test/src/test/scala/monocle/TestInstances.scala
@@ -50,6 +50,16 @@ trait TestInstances {
   implicit def tuple5Eq[A1: Equal, A2: Equal, A3: Equal, A4: Equal, A5: Equal] = scalaz.std.tuple.tuple5Equal[A1, A2, A3, A4, A5]
   implicit def tuple6Eq[A1: Equal, A2: Equal, A3: Equal, A4: Equal, A5: Equal, A6: Equal] = scalaz.std.tuple.tuple6Equal[A1, A2, A3, A4, A5, A6]
 
+  implicit def optionCofreeEq[A](implicit A: Equal[A]): Equal[Cofree[Option, A]] =
+    Cofree.cofreeEqual(A, new (NaturalTransformation[Equal, ({type λ[X] = Equal[Option[X]]})#λ]) {
+      override def apply[A](a: Equal[A]): Equal[Option[A]] = optEq(a)
+    })
+
+  implicit def streamCofreeEq[A](implicit A: Equal[A]): Equal[Cofree[Stream, A]] =
+    Cofree.cofreeEqual(A, new (NaturalTransformation[Equal, ({type λ[X] = Equal[Stream[X]]})#λ]) {
+      override def apply[A](a: Equal[A]): Equal[Stream[A]] = streamEq(a)
+    })
+
   // Order instances
 
   implicit val intOrder = Order.fromScalaOrdering[Int]
@@ -144,5 +154,13 @@ trait TestInstances {
       Arbitrary.arbitrary[B].map(Either3.middle3),
       Arbitrary.arbitrary[C].map(Either3.right3)
     ))
+
+  implicit def optionCofreeArbitrary[A](implicit A: Arbitrary[A]): Arbitrary[Cofree[Option, A]] =
+    Arbitrary(Arbitrary.arbitrary[OneAnd[List, A]].map( xs =>
+      monocle.std.cofree.cofreeToStream.reverseGet(xs.copy(tail = xs.tail.toStream))
+    ))
+
+  implicit def streamCofreeArbitrary[A](implicit A: Arbitrary[A]): Arbitrary[Cofree[Stream, A]] =
+    Arbitrary(Arbitrary.arbitrary[Tree[A]].map( monocle.std.cofree.cofreeToTree.reverseGet))
 
 }

--- a/test/src/test/scala/monocle/std/CofreeSpec.scala
+++ b/test/src/test/scala/monocle/std/CofreeSpec.scala
@@ -1,18 +1,16 @@
 package monocle.std
 
 import monocle.MonocleSuite
-import monocle.law.discipline.{IsoTests, TraversalTests}
+import monocle.law.discipline.IsoTests
 import monocle.law.discipline.function._
 
 import scalaz.Cofree
-import scalaz.Cofree._
-import scalaz.std.option._
+import scalaz.std.option.optionInstance
 
 class CofreeSpec extends MonocleSuite {
-  // TODO: need Arbitrary and Equal instances for Cofree
-  // checkAll("pCofreeToStream", IsoTests(pCofreeToStream[Int, Int]))
-  // checkAll("pCofreeToTree", IsoTests(pCofreeToTree[Int, Int]))
-  // checkAll("cons cofree", ConsTests[Cofree[Option, Int], Int])
-  // checkAll("each cofree", EachTests[Cofree[Option, Int], Int])
+   checkAll("cofreeToStream", IsoTests(cofreeToStream[Int]))
+   checkAll("cofreeToTree", IsoTests(cofreeToTree[Int]))
+   checkAll("cons1 cofree", Cons1Tests[Cofree[Option, Int], Int, Option[Cofree[Option, Int]]])
+   checkAll("each cofree", EachTests[Cofree[Option, Int], Int])
 }
 

--- a/test/src/test/scala/monocle/std/CofreeSpec.scala
+++ b/test/src/test/scala/monocle/std/CofreeSpec.scala
@@ -1,0 +1,18 @@
+package monocle.std
+
+import monocle.MonocleSuite
+import monocle.law.discipline.{IsoTests, TraversalTests}
+import monocle.law.discipline.function._
+
+import scalaz.Cofree
+import scalaz.Cofree._
+import scalaz.std.option._
+
+class CofreeSpec extends MonocleSuite {
+  // TODO: need Arbitrary and Equal instances for Cofree
+  // checkAll("pCofreeToStream", IsoTests(pCofreeToStream[Int, Int]))
+  // checkAll("pCofreeToTree", IsoTests(pCofreeToTree[Int, Int]))
+  // checkAll("cons cofree", ConsTests[Cofree[Option, Int], Int])
+  // checkAll("each cofree", EachTests[Cofree[Option, Int], Int])
+}
+


### PR DESCRIPTION
For https://github.com/julien-truffaut/Monocle/issues/177

* [x] ~~`(p)Heads` - `(P)Traversal` over the head values of a cofree traversable structure~~
* [x] `Each` instance for `Cofree`
* [x] `(p)CofreeToStream` - `(P)Iso` between `Cofree Option` and `OneAnd Stream`
* [x] `(p)CofreeToTree` - `(P)Iso` between `Cofree Stream` and `Tree`
* [x] `Cons1` instance for `Cofree`
* [x] Tests - need `Arbitrary` instance for `Cofree`