### PR TITLE
Rename subproject and package to refined

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ lazy val buildSettings = Seq(
 
 lazy val scalaz     = "org.scalaz"      %% "scalaz-core" % "7.1.4"
 lazy val shapeless  = "com.chuusai"     %% "shapeless"   % "2.2.5"
-lazy val refined    = "eu.timepit"      %% "refined"     % "0.3.1"
+lazy val refinedDep = "eu.timepit"      %% "refined"     % "0.3.1"
 
 lazy val discpline  = "org.typelevel"   %% "discipline"  % "0.3"
 lazy val scalatest  = "org.scalatest"   %% "scalatest"   % "2.2.4"  % "test"
@@ -66,10 +66,10 @@ lazy val generic = project.dependsOn(core)
   .settings(mimaSettings("generic"))
   .settings(libraryDependencies := Seq(scalaz, shapeless))
 
-lazy val refine = project.dependsOn(core)
-  .settings(moduleName := "monocle-refine")
+lazy val refined = project.dependsOn(core)
+  .settings(moduleName := "monocle-refined")
   .settings(monocleSettings)
-  .settings(libraryDependencies := Seq(scalaz, refined))
+  .settings(libraryDependencies := Seq(scalaz, refinedDep))
 
 lazy val law = project.dependsOn(core)
   .settings(moduleName := "monocle-law")
@@ -99,7 +99,7 @@ lazy val state = project.dependsOn(core)
   .settings(monocleSettings)
   .settings(libraryDependencies := Seq(scalaz))
 
-lazy val test = project.dependsOn(core, generic, macros, law, state, refine)
+lazy val test = project.dependsOn(core, generic, macros, law, state, refined)
   .settings(moduleName := "monocle-test")
   .settings(monocleSettings)
   .settings(noPublishSettings)
@@ -116,7 +116,7 @@ lazy val bench = project.dependsOn(core, macros)
     compilerPlugin(paradisePlugin)
   )).enablePlugins(JmhPlugin)
 
-lazy val example = project.dependsOn(core, generic, refine, macros, state, test % "test->test")
+lazy val example = project.dependsOn(core, generic, refined, macros, state, test % "test->test")
   .settings(moduleName := "monocle-example")
   .settings(monocleSettings)
   .settings(noPublishSettings)

--- a/example/src/test/scala/monocle/function/AtExample.scala
+++ b/example/src/test/scala/monocle/function/AtExample.scala
@@ -2,7 +2,7 @@ package monocle.function
 
 import eu.timepit.refined._
 import monocle.MonocleSuite
-import monocle.refine._
+import monocle.refined._
 import shapeless.test.illTyped
 import eu.timepit.refined.auto._
 

--- a/refine/src/main/scala/monocle/refine/All.scala
+++ b/refine/src/main/scala/monocle/refine/All.scala
@@ -1,5 +1,0 @@
-package monocle.refine
-
-object all extends RefineInstances
-
-trait RefineInstances extends BitsInstances

--- a/refined/src/main/scala/monocle/refined/All.scala
+++ b/refined/src/main/scala/monocle/refined/All.scala
@@ -1,0 +1,5 @@
+package monocle.refined
+
+object all extends RefinedInstances
+
+trait RefinedInstances extends BitsInstances

--- a/refined/src/main/scala/monocle/refined/bits.scala
+++ b/refined/src/main/scala/monocle/refined/bits.scala
@@ -1,7 +1,7 @@
-package monocle.refine
+package monocle.refined
 
 import monocle.function.At
-import monocle.refine.internal.Bits
+import monocle.refined.internal.Bits
 
 object bits extends BitsInstances
 

--- a/refined/src/main/scala/monocle/refined/internal/Bits.scala
+++ b/refined/src/main/scala/monocle/refined/internal/Bits.scala
@@ -1,4 +1,4 @@
-package monocle.refine.internal
+package monocle.refined.internal
 
 private[monocle] trait Bits[A] {
 

--- a/refined/src/main/scala/monocle/refined/package.scala
+++ b/refined/src/main/scala/monocle/refined/package.scala
@@ -4,7 +4,7 @@ import eu.timepit.refined._
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.numeric.Interval
 
-package object refine {
+package object refined {
   type ZeroTo[T] = Int Refined Interval[W.`0`.T, T]
 
   type ByteBits = ZeroTo[W.`7`.T]

--- a/test/src/test/scala/monocle/MonocleSuite.scala
+++ b/test/src/test/scala/monocle/MonocleSuite.scala
@@ -2,7 +2,7 @@ package monocle
 
 import monocle.function.GenericOptics
 import monocle.generic.GenericInstances
-import monocle.refine.RefineInstances
+import monocle.refined.RefinedInstances
 import monocle.state.StateLensSyntax
 import monocle.std.StdInstances
 import monocle.syntax.Syntaxes
@@ -16,6 +16,6 @@ trait MonocleSuite extends FunSuite
                       with StdInstances
                       with GenericOptics
                       with GenericInstances
-                      with RefineInstances
+                      with RefinedInstances
                       with Syntaxes
                       with StateLensSyntax

--- a/test/src/test/scala/monocle/refined/BitsSpec.scala
+++ b/test/src/test/scala/monocle/refined/BitsSpec.scala
@@ -1,4 +1,4 @@
-package monocle.refine
+package monocle.refined
 
 import eu.timepit.refined._
 import eu.timepit.refined.auto._


### PR DESCRIPTION
It seems that this doesn't cause any problems in `AtExample.scala` where we have both imports:
```scala
import eu.timepit.refined._
import monocle.refined._
```