### PR TITLE
Using container-based infrastructure on Travis CI build job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,9 @@ env:
   - secure: lJxaR+9VM96s7rfaigL3K2FbcP3XiZ+AerbgOBOpYi2anRkMPQ91h1g60HYTwEDGJIKybyNWFuXZM8hNtQMCxzxgu7ev1SyRr5Otfzg5ehGqB5UWbSAgpXlqhR5dAonwmqyEEDF2OK+k1fa0N6mIwpQeuUCwrt68kTp4f0K9jMQ=
   - secure: NZQn8lB04I+FO3Om680CXWP29scS/zRhITbLO/1sM3dnuG8ygn0fzlFMQhgCO3fCjnclThAi+6MN7UnyV8BwDbFhCDe627+06px5fHUw2TPdzhz/BwngAW9pRsx6m0b8eBqQmt8Q6mlgeYOPemsFOeqQTKZulpIhSYnO1R1Nwzc=
 sudo: false
+cache:
+  directories:
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt/boot
 after_success:
 - '[[ $TRAVIS_BRANCH == "master" ]] && { sbt +publish; };'

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,6 @@ env:
   global:
   - secure: lJxaR+9VM96s7rfaigL3K2FbcP3XiZ+AerbgOBOpYi2anRkMPQ91h1g60HYTwEDGJIKybyNWFuXZM8hNtQMCxzxgu7ev1SyRr5Otfzg5ehGqB5UWbSAgpXlqhR5dAonwmqyEEDF2OK+k1fa0N6mIwpQeuUCwrt68kTp4f0K9jMQ=
   - secure: NZQn8lB04I+FO3Om680CXWP29scS/zRhITbLO/1sM3dnuG8ygn0fzlFMQhgCO3fCjnclThAi+6MN7UnyV8BwDbFhCDe627+06px5fHUw2TPdzhz/BwngAW9pRsx6m0b8eBqQmt8Q6mlgeYOPemsFOeqQTKZulpIhSYnO1R1Nwzc=
+sudo: false
 after_success:
 - '[[ $TRAVIS_BRANCH == "master" ]] && { sbt +publish; };'


### PR DESCRIPTION
Monocle repos seems to use not container-based infrastructure but standard infrastructure on Travis CI build job.

So I added `sudo: false` explicitly.
There is advantages that:
* build faster
* cache available (despite public repos)

ref: https://docs.travis-ci.com/user/workers/container-based-infrastructure/