### PR TITLE
fix implicitNotFound message of Plated

### DIFF
--- a/core/src/main/scala/monocle/function/Plated.scala
+++ b/core/src/main/scala/monocle/function/Plated.scala
@@ -11,7 +11,7 @@ import scalaz.std.stream._
   *
   * @tparam A the parent and child type of a [[Plated]]
   */
-@implicitNotFound("Could not find an instance of Plated[{A}], please check Monocle instance location policy to " +
+@implicitNotFound("Could not find an instance of Plated[${A}], please check Monocle instance location policy to " +
   "find out which import is necessary")
 abstract class Plated[A] extends Serializable { self =>
   def plate: Traversal[A, A]


### PR DESCRIPTION
before:
```scala
scala> monocle.function.Plated.children(100)
<console>:11: error: Could not find an instance of Plated[{A}], please check Monocle instance location policy to find out which import is necessary
       monocle.function.Plated.children(100)
                                       ^
```

after:
```scala
scala> monocle.function.Plated.children(100)
<console>:11: error: Could not find an instance of Plated[Int], please check Monocle instance location policy to find out which import is necessary
       monocle.function.Plated.children(100)
                                       ^
```