### PR TITLE
Cats documentation has moved to Typelevel.org

### DIFF
--- a/docs/src/site/typeclasses.md
+++ b/docs/src/site/typeclasses.md
@@ -7,7 +7,7 @@ section: "typeclasses"
 # Typeclasses
 
 Monocle defines typeclasses to fetch generic optics implicitly. You can find more information about typeclass pattern in 
-[cats](http://non.github.io/cats//typeclasses.html).
+[cats](http://typelevel.org/cats/typeclasses.html).
 
 Here is the list of typeclasses defined in Monocle:
 


### PR DESCRIPTION
Just updating the Cats link.