### PR TITLE
Fix #336 (partially) Add logic to exclude unlawful Strings 

### DIFF
--- a/core/shared/src/main/scala/monocle/std/String.scala
+++ b/core/shared/src/main/scala/monocle/std/String.scala
@@ -81,13 +81,19 @@ trait StringOptics {
     }
   }
 
-  private def parseLong(s: String): Option[Long] =
-    if (s.isEmpty) None
+  private def parseLong(s: String): Option[Long] = {
+    // we reject case where String starts with +, otherwise it will be an invalid Prism according 2nd Prism law
+    // we reject case where String starts with 0 and has multiple digits, otherwise it will be an invalid Prism according 2nd Prism law
+    def inputBreaksPrismLaws(input: String): Boolean =
+      s.isEmpty || s.startsWith("+") || (s.startsWith("0") && s.length > 1)
+
+    if (inputBreaksPrismLaws(s)) None
     else s.toList match {
       case '-' :: xs => parseLongUnsigned(xs).map(-_)
-      case xs        => parseLongUnsigned(xs)
-      // we reject case where String starts with +, otherwise it will be an invalid Prism according 2nd Prism law
+      case xs => parseLongUnsigned(xs)
+
     }
+  }
 
   private def parseLongUnsigned(s: List[Char]): Option[Long] =
     if(s.isEmpty) None

--- a/core/shared/src/main/scala/monocle/std/String.scala
+++ b/core/shared/src/main/scala/monocle/std/String.scala
@@ -82,16 +82,16 @@ trait StringOptics {
   }
 
   private def parseLong(s: String): Option[Long] = {
-    // we reject case where String starts with +, otherwise it will be an invalid Prism according 2nd Prism law
-    // we reject case where String starts with 0 and has multiple digits, otherwise it will be an invalid Prism according 2nd Prism law
+    // we reject cases where String will be an invalid Prism according 2nd Prism law
+    // * String starts with +
+    // * String starts with 0 and has multiple digits
     def inputBreaksPrismLaws(input: String): Boolean =
       s.isEmpty || s.startsWith("+") || (s.startsWith("0") && s.length > 1)
 
     if (inputBreaksPrismLaws(s)) None
     else s.toList match {
       case '-' :: xs => parseLongUnsigned(xs).map(-_)
-      case xs => parseLongUnsigned(xs)
-
+      case        xs => parseLongUnsigned(xs)
     }
   }
 

--- a/test/shared/src/test/scala/monocle/RegressionSpec.scala
+++ b/test/shared/src/test/scala/monocle/RegressionSpec.scala
@@ -1,10 +1,18 @@
 package monocle
 
-
 class RegressionSpec extends MonocleSuite {
 
   test("#244 - String to Long: '-' to long should not succeed.") {
     stringToLong.getOption("-") shouldEqual None
+  }
+
+  test("#336 - String to Long: '001' to long should not succeed.") {
+    stringToLong.modifyOption(identity)("001") shouldEqual None
+    stringToLong.modify(identity)("001") shouldEqual "001"
+  }
+
+  test("#336 - String to Long: '0' should succeed.") {
+    stringToLong.modifyOption(identity)("0") shouldEqual Some("0")
   }
 
 }


### PR DESCRIPTION
For String-to-Long Prism and derivatives (String-to-Int, String-to-Byte)
