### PR TITLE
336 - stringToBoolean to respect Prism laws

### DIFF
--- a/core/shared/src/main/scala/monocle/std/String.scala
+++ b/core/shared/src/main/scala/monocle/std/String.scala
@@ -4,7 +4,7 @@ import monocle.function._
 import monocle.std.list._
 import monocle.{Iso, Prism, Traversal}
 
-import scalaz.{Applicative, \/}
+import scalaz.Applicative
 import scalaz.std.list._
 import scalaz.std.option._
 import scalaz.syntax.traverse._
@@ -17,7 +17,7 @@ trait StringOptics {
     Iso((_: String).toList)(_.mkString)
 
   val stringToBoolean: Prism[String, Boolean] =
-    Prism{s: String => \/.fromTryCatchNonFatal(s.toBoolean).toOption}(_.toString)
+    Prism{s: String => parseCaseSensitiveBoolean(s)}(_.toString)
 
   val stringToLong: Prism[String, Long] =
     Prism(parseLong)(_.toString)
@@ -103,4 +103,9 @@ trait StringOptics {
     if (c >= '0' && c <= '9') Some(c - '0')
     else None
 
+  private def parseCaseSensitiveBoolean(stringBoolean: String): Option[Boolean] = stringBoolean match {
+    case "true" => Some(true)
+    case "false" => Some(false)
+    case _ => None
+  }
 }

--- a/test/shared/src/test/scala/monocle/RegressionSpec.scala
+++ b/test/shared/src/test/scala/monocle/RegressionSpec.scala
@@ -15,4 +15,12 @@ class RegressionSpec extends MonocleSuite {
     stringToLong.modifyOption(identity)("0") shouldEqual Some("0")
   }
 
+  test("#336 - Uppercase booleans not obeying Prism laws") {
+    stringToBoolean.modifyOption(identity)("TRUE") should be (None)
+    stringToBoolean.modifyOption(identity)("False") should be (None)
+
+    stringToBoolean.modify(identity)("true") should be ("true")
+    stringToBoolean.modify(identity)("false") should be ("false")
+  }
+
 }


### PR DESCRIPTION
This PR makes the String to Boolean Prism to respect Prism laws by constraining the string input to only be lowercase.

This also removes the usage of Scalaz's Disjunction since Exceptions are not being raised any more.