### PR TITLE
Add sans to At

### DIFF
--- a/core/shared/src/main/scala/monocle/function/At.scala
+++ b/core/shared/src/main/scala/monocle/function/At.scala
@@ -32,4 +32,7 @@ object At extends AtFunctions {
 
 trait AtFunctions {
   def at[S, I, A](i: I)(implicit ev: At[S, I, A]): Lens[S, A] = ev.at(i)
+
+  def sans[S, I, A](i: I)(s: S)(implicit ev: At[S, I, Option[A]]): S =
+    ev.at(i).set(None)(s)
 }

--- a/example/src/test/scala/monocle/function/AtExample.scala
+++ b/example/src/test/scala/monocle/function/AtExample.scala
@@ -55,4 +55,8 @@ class AtExample extends MonocleSuite {
     ('x' applyLens at(0: CharBits) set true) shouldEqual 'y'
   }
 
+  test("sans deletes an element of a Map") {
+    sans("Foo")(Map("Foo" -> 1, "Bar" -> 2)) shouldEqual Map("Bar" -> 2)
+  }
+
 }

--- a/test/shared/src/test/scala/monocle/function/AtSpec.scala
+++ b/test/shared/src/test/scala/monocle/function/AtSpec.scala
@@ -2,11 +2,27 @@ package monocle.function
 
 import monocle.MonocleSuite
 import monocle.law.discipline.function.AtTests
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
-class AtSpec extends MonocleSuite {
+class AtSpec extends MonocleSuite with GeneratorDrivenPropertyChecks {
 
   implicit def mmapAt[K, V]: At[MMap[K, V], K, Option[V]] = At.fromIso(MMap.toMap)
 
   checkAll("fromIso", AtTests.defaultIntIndex[MMap[Int, String], Option[String]])
+
+  test("sans deletes a key") {
+
+    val mapAndIndexGen: Gen[(Map[Int, String], Int)] = for {
+      m <- Arbitrary.arbitrary[Map[Int, String]]
+      i <- Gen.frequency(
+        (8, Gen.oneOf(m.keys.toList)),
+        (2, Arbitrary.arbInt.arbitrary))
+    } yield (m, i)
+
+    forAll(mapAndIndexGen) { case (m, i) =>
+      sans(i)(m) should be (m - i)
+    }
+  }
 
 }


### PR DESCRIPTION
Add function 'sans' to delete a value associated with a key in a Map-like container.