### PR TITLE
Introduce generic Each derivation

### DIFF
--- a/generic/shared/src/main/scala/monocle/generic/Product.scala
+++ b/generic/shared/src/main/scala/monocle/generic/Product.scala
@@ -1,11 +1,35 @@
 package monocle.generic
 
-import monocle.Iso
+import language.higherKinds
+import monocle.PTraversal
+import monocle.function.Each
+import monocle.{ Iso, Traversal }
 import monocle.generic.internal.TupleGeneric
+import scalaz.Applicative
+import scalaz.syntax.apply._
+import shapeless.{ ::, Generic, HList, HNil }
 
 object product extends ProductOptics
 
 trait ProductOptics {
   def productToTuple[S <: Product](implicit ev: TupleGeneric[S]): Iso[S, ev.Repr] =
     Iso[S, ev.Repr](s => ev.to(s))(t => ev.from(t))
+
+  implicit def hNilEach[A] = new Each[HNil, A] {
+    def each: Traversal[HNil, A] = Traversal.void[HNil, A]
+  }
+
+  implicit def hConsEach[A, Rest <: HList](implicit restEach: Each[Rest, A]) = new Each[A :: Rest, A] {
+    def each: Traversal[A :: Rest, A] = new PTraversal[A :: Rest, A :: Rest, A, A] {
+      def modifyF[F[_]: Applicative](f: A => F[A])(s: A :: Rest): F[A :: Rest] =
+        (f(s.head) |@| restEach.each.modifyF(f)(s.tail)).apply(_ :: _)
+    }
+  }
+
+  implicit def productEach[S, SGen <: HList, A](implicit gen: Generic.Aux[S, SGen], genEach: Each[SGen, A]): Each[S, A] = new Each[S, A] {
+    def each: Traversal[S, A] = new Traversal[S, A] {
+      def modifyF[F[_]: Applicative](f: A => F[A])(s: S): F[S] =
+        Applicative[F].map(genEach.each.modifyF(f)(gen.to(s)))(gen.from)
+    }
+  }
 }

--- a/test/shared/src/test/scala/monocle/generic/ProductSpec.scala
+++ b/test/shared/src/test/scala/monocle/generic/ProductSpec.scala
@@ -2,6 +2,7 @@ package monocle.generic
 
 import monocle.MonocleSuite
 import monocle.law.discipline.IsoTests
+import monocle.law.discipline.function.EachTests
 import org.scalacheck.Arbitrary
 
 import scalaz.Equal
@@ -11,10 +12,23 @@ class ProductSpec extends MonocleSuite {
   case class Person(name: String, age: Int)
 
   implicit val personEq: Equal[Person] = Equal.equalA
-  implicit val personArb: Arbitrary[Person] = Arbitrary(for{
+  implicit val personArb: Arbitrary[Person] = Arbitrary(for {
     n <- Arbitrary.arbitrary[String]
     a <- Arbitrary.arbitrary[Int]
   } yield Person(n, a))
 
+  case class Permissions(read: Boolean, write: Boolean, execute: Boolean)
+
+  implicit val nameEq: Equal[Permissions] = Equal.equalA
+  implicit val nameArb: Arbitrary[Permissions] = Arbitrary(for {
+    f <- Arbitrary.arbitrary[Boolean]
+    l <- Arbitrary.arbitrary[Boolean]
+    i <- Arbitrary.arbitrary[Boolean]
+  } yield Permissions(f, l, i))
+
   checkAll("toTuple", IsoTests(product.productToTuple[Person]))
+
+  checkAll("eachTuple2", EachTests[(String, String), String])
+  checkAll("eachTuple4", EachTests[(Int, Int, Int, Int), Int])
+  checkAll("eachCaseClass", EachTests[Permissions, Boolean])
 }


### PR DESCRIPTION
Implement a generic `Each` instance for any product tuple and case class which wraps all entities of the same type using shapeless typeclass derivation.

I didn't put the tests in `TupleNSpec` because I realised after leaving the hack-day that this would have worked with any product type, including case classes.