### PR TITLE
Treat PPrisms as smart constructors for type T.

### DIFF
--- a/core/shared/src/main/scala/monocle/Iso.scala
+++ b/core/shared/src/main/scala/monocle/Iso.scala
@@ -1,6 +1,8 @@
 package monocle
 
 import scalaz.Isomorphism.{<=>, <~>}
+import scalaz.Leibniz.===
+import scalaz.Liskov.<~<
 import scalaz.{Applicative, Category, Functor, Maybe, Monoid, Split, \/}
 
 /**
@@ -255,6 +257,28 @@ abstract class PIso[S, T, A, B] extends Serializable { self =>
         self.modifyF(f)(s)
     }
 
+  /*************************************************************************/
+  /** Apply methods to treat a [[PIso]] as smart constructors for type T */
+  /*************************************************************************/
+
+  def apply()(implicit ev: B === Unit): T =
+    ev.subst[({type λ[α] = PIso[S, T, A, α]})#λ](self).reverseGet(())
+
+  def apply(b: B): T = reverseGet(b)
+
+  def apply[C, D](c: C, d: D)(implicit ev: (C, D) <~< B): T = apply(ev((c, d)))
+
+  def apply[C, D, E](c: C, d: D, e: E)(implicit ev: (C, D, E) <~< B): T =
+    apply(ev((c, d, e)))
+
+  def apply[C, D, E, F](c: C, d: D, e: E, f: F)(implicit ev: (C, D, E, F) <~< B): T =
+    apply(ev((c, d, e, f)))
+
+  def apply[C, D, E, F, G](c: C, d: D, e: E, f: F, g: G)(implicit ev: (C, D, E, F, G) <~< B): T =
+    apply(ev((c, d, e, f, g)))
+
+  def apply[C, D, E, F, G, H](c: C, d: D, e: E, f: F, g: G, h: H)(implicit ev: (C, D, E, F, G, H) <~< B): T =
+    apply(ev((c, d, e, f, g, h)))
 }
 
 object PIso extends IsoInstances {

--- a/core/shared/src/main/scala/monocle/Prism.scala
+++ b/core/shared/src/main/scala/monocle/Prism.scala
@@ -1,8 +1,8 @@
 package monocle
 
-import scalaz.{Applicative, Category, Equal, Leibniz, Liskov, Maybe, Monoid, Traverse, \/},
-  Leibniz.===,
-  Liskov.<~<
+import scalaz.Leibniz.===
+import scalaz.Liskov.<~<
+import scalaz.{Applicative, Category, Equal, Maybe, Monoid, Traverse, \/}
 import scalaz.std.option._
 import scalaz.syntax.std.option._
 

--- a/core/shared/src/main/scala/monocle/Prism.scala
+++ b/core/shared/src/main/scala/monocle/Prism.scala
@@ -1,6 +1,8 @@
 package monocle
 
-import scalaz.{Applicative, Category, Equal, Maybe, Monoid, Traverse, \/}
+import scalaz.{Applicative, Category, Equal, Leibniz, Liskov, Maybe, Monoid, Traverse, \/},
+  Leibniz.===,
+  Liskov.<~<
 import scalaz.std.option._
 import scalaz.syntax.std.option._
 
@@ -228,6 +230,29 @@ abstract class PPrism[S, T, A, B] extends Serializable { self =>
       def modifyF[F[_]: Applicative](f: A => F[B])(s: S): F[T] =
         self.modifyF(f)(s)
     }
+
+  /*************************************************************************/
+  /** Apply methods to treat a [[PPrism]] as smart constructors for type T */
+  /*************************************************************************/
+
+  def apply()(implicit ev: B === Unit): T =
+    ev.subst[({type λ[α] = PPrism[S, T, A, α]})#λ](self).reverseGet(())
+
+  def apply(b: B): T = reverseGet(b)
+
+  def apply[C, D](c: C, d: D)(implicit ev: (C, D) <~< B): T = apply(ev((c, d)))
+
+  def apply[C, D, E](c: C, d: D, e: E)(implicit ev: (C, D, E) <~< B): T =
+    apply(ev((c, d, e)))
+
+  def apply[C, D, E, F](c: C, d: D, e: E, f: F)(implicit ev: (C, D, E, F) <~< B): T =
+    apply(ev((c, d, e, f)))
+
+  def apply[C, D, E, F, G](c: C, d: D, e: E, f: F, g: G)(implicit ev: (C, D, E, F, G) <~< B): T =
+    apply(ev((c, d, e, f, g)))
+
+  def apply[C, D, E, F, G, H](c: C, d: D, e: E, f: F, g: G, h: H)(implicit ev: (C, D, E, F, G, H) <~< B): T =
+    apply(ev((c, d, e, f, g, h)))
 }
 
 object PPrism extends PrismInstances {

--- a/test/shared/src/test/scala/monocle/Arities.scala
+++ b/test/shared/src/test/scala/monocle/Arities.scala
@@ -4,5 +4,5 @@ sealed trait Arities
 final case class Nullary() extends Arities
 final case class Unary(i: Int) extends Arities
 final case class Binary(s: String, i: Int) extends Arities
-final case class Quintary(u: Unit, b: Boolean, s: String, i: Int, f: Double)
+final case class Quintary(a: Any, b: Boolean, s: String, i: Int, f: Double)
     extends Arities

--- a/test/shared/src/test/scala/monocle/Arities.scala
+++ b/test/shared/src/test/scala/monocle/Arities.scala
@@ -4,5 +4,5 @@ sealed trait Arities
 final case class Nullary() extends Arities
 final case class Unary(i: Int) extends Arities
 final case class Binary(s: String, i: Int) extends Arities
-final case class Quintary(a: Any, b: Boolean, s: String, i: Int, f: Double)
+final case class Quintary(c: Char, b: Boolean, s: String, i: Int, f: Double)
     extends Arities

--- a/test/shared/src/test/scala/monocle/Arities.scala
+++ b/test/shared/src/test/scala/monocle/Arities.scala
@@ -1,0 +1,8 @@
+package monocle
+
+sealed trait Arities
+final case class Nullary() extends Arities
+final case class Unary(i: Int) extends Arities
+final case class Binary(s: String, i: Int) extends Arities
+final case class Quintary(u: Unit, b: Boolean, s: String, i: Int, f: Double)
+    extends Arities

--- a/test/shared/src/test/scala/monocle/IsoSpec.scala
+++ b/test/shared/src/test/scala/monocle/IsoSpec.scala
@@ -16,9 +16,9 @@ class IsoSpec extends MonocleSuite {
   val _unary: Iso[Unary, Int] = Iso[Unary, Int](_.i)(Unary)
   val _binary: Iso[Binary, (String, Int)] =
     Iso[Binary, (String, Int)](b => (b.s, b.i))(Binary.tupled)
-  val _quintary: Iso[Quintary, (Unit, Boolean, String, Int, Double)] =
-    Iso[Quintary, (Unit, Boolean, String, Int, Double)](
-      b => (b.u, b.b, b.s, b.i, b.f))(
+  val _quintary: Iso[Quintary, (Any, Boolean, String, Int, Double)] =
+    Iso[Quintary, (Any, Boolean, String, Int, Double)](
+      b => (b.a, b.b, b.s, b.i, b.f))(
       Quintary.tupled)
 
   case class IntWrapper(i: Int)

--- a/test/shared/src/test/scala/monocle/IsoSpec.scala
+++ b/test/shared/src/test/scala/monocle/IsoSpec.scala
@@ -16,9 +16,9 @@ class IsoSpec extends MonocleSuite {
   val _unary: Iso[Unary, Int] = Iso[Unary, Int](_.i)(Unary)
   val _binary: Iso[Binary, (String, Int)] =
     Iso[Binary, (String, Int)](b => (b.s, b.i))(Binary.tupled)
-  val _quintary: Iso[Quintary, (Any, Boolean, String, Int, Double)] =
-    Iso[Quintary, (Any, Boolean, String, Int, Double)](
-      b => (b.a, b.b, b.s, b.i, b.f))(
+  val _quintary: Iso[Quintary, (Char, Boolean, String, Int, Double)] =
+    Iso[Quintary, (Char, Boolean, String, Int, Double)](
+      b => (b.c, b.b, b.s, b.i, b.f))(
       Quintary.tupled)
 
   case class IntWrapper(i: Int)
@@ -81,8 +81,8 @@ class IsoSpec extends MonocleSuite {
     _nullary() shouldEqual Nullary()
     _unary(3) shouldEqual Unary(3)
     _binary("foo", 7) shouldEqual Binary("foo", 7)
-    _quintary((), true, "bar", 13, 0.4) shouldEqual
-      Quintary((), true, "bar", 13, 0.4)
+    _quintary('x', true, "bar", 13, 0.4) shouldEqual
+      Quintary('x', true, "bar", 13, 0.4)
   }
 }
 

--- a/test/shared/src/test/scala/monocle/IsoSpec.scala
+++ b/test/shared/src/test/scala/monocle/IsoSpec.scala
@@ -10,6 +10,17 @@ import scalaz.{Category, Compose, Equal, Split}
 
 class IsoSpec extends MonocleSuite {
 
+  val _nullary: Iso[Nullary, Unit] = Iso[Nullary, Unit](n => ()) {
+    case () => Nullary()
+  }
+  val _unary: Iso[Unary, Int] = Iso[Unary, Int](_.i)(Unary)
+  val _binary: Iso[Binary, (String, Int)] =
+    Iso[Binary, (String, Int)](b => (b.s, b.i))(Binary.tupled)
+  val _quintary: Iso[Quintary, (Unit, Boolean, String, Int, Double)] =
+    Iso[Quintary, (Unit, Boolean, String, Int, Double)](
+      b => (b.u, b.b, b.s, b.i, b.f))(
+      Quintary.tupled)
+
   case class IntWrapper(i: Int)
   implicit val intWrapperGen: Arbitrary[IntWrapper] = Arbitrary(arbitrary[Int].map(IntWrapper.apply))
   implicit val intWrapperEq = Equal.equalA[IntWrapper]
@@ -66,6 +77,12 @@ class IsoSpec extends MonocleSuite {
     Split[Iso].split(iso, iso.reverse).get((IntWrapper(3), 3)) shouldEqual ((3, IntWrapper(3)))
   }
 
-
+  test("apply") {
+    _nullary() shouldEqual Nullary()
+    _unary(3) shouldEqual Unary(3)
+    _binary("foo", 7) shouldEqual Binary("foo", 7)
+    _quintary((), true, "bar", 13, 0.4) shouldEqual
+      Quintary((), true, "bar", 13, 0.4)
+  }
 }
 

--- a/test/shared/src/test/scala/monocle/PrismSpec.scala
+++ b/test/shared/src/test/scala/monocle/PrismSpec.scala
@@ -26,9 +26,9 @@ class PrismSpec extends MonocleSuite {
       case Binary(s, i) => Some((s, i))
       case _            => None
     } (Binary.tupled)
-  val _quintary: Prism[Arities, (Unit, Boolean, String, Int, Double)] =
-    Prism[Arities, (Unit, Boolean, String, Int, Double)] {
-      case Quintary(u, b, s, i, f) => Some((u, b, s, i, f))
+  val _quintary: Prism[Arities, (Any, Boolean, String, Int, Double)] =
+    Prism[Arities, (Any, Boolean, String, Int, Double)] {
+      case Quintary(a, b, s, i, f) => Some((a, b, s, i, f))
       case _                       => None
     } (Quintary.tupled)
 

--- a/test/shared/src/test/scala/monocle/PrismSpec.scala
+++ b/test/shared/src/test/scala/monocle/PrismSpec.scala
@@ -26,9 +26,9 @@ class PrismSpec extends MonocleSuite {
       case Binary(s, i) => Some((s, i))
       case _            => None
     } (Binary.tupled)
-  val _quintary: Prism[Arities, (Any, Boolean, String, Int, Double)] =
-    Prism[Arities, (Any, Boolean, String, Int, Double)] {
-      case Quintary(a, b, s, i, f) => Some((a, b, s, i, f))
+  val _quintary: Prism[Arities, (Char, Boolean, String, Int, Double)] =
+    Prism[Arities, (Char, Boolean, String, Int, Double)] {
+      case Quintary(c, b, s, i, f) => Some((c, b, s, i, f))
       case _                       => None
     } (Quintary.tupled)
 
@@ -68,7 +68,7 @@ class PrismSpec extends MonocleSuite {
     _nullary() shouldEqual Nullary()
     _unary(3) shouldEqual Unary(3)
     _binary("foo", 7) shouldEqual Binary("foo", 7)
-    _quintary((), true, "bar", 13, 0.4) shouldEqual
-      Quintary((), true, "bar", 13, 0.4)
+    _quintary('x', true, "bar", 13, 0.4) shouldEqual
+      Quintary('x', true, "bar", 13, 0.4)
   }
 }

--- a/test/shared/src/test/scala/monocle/PrismSpec.scala
+++ b/test/shared/src/test/scala/monocle/PrismSpec.scala
@@ -9,6 +9,30 @@ class PrismSpec extends MonocleSuite {
 
   def _right[E, A]: Prism[E \/ A, A] = Prism[E \/ A, A](_.toOption)(\/.right)
 
+  val _nullary: Prism[Arities, Unit] =
+    Prism[Arities, Unit] {
+      case Nullary() => Some(())
+      case _         => None
+    } {
+      case () => Nullary()
+    }
+  val _unary: Prism[Arities, Int] =
+    Prism[Arities, Int] {
+      case Unary(i) => Some(i)
+      case _        => None
+    } (Unary)
+  val _binary: Prism[Arities, (String, Int)] =
+    Prism[Arities, (String, Int)] {
+      case Binary(s, i) => Some((s, i))
+      case _            => None
+    } (Binary.tupled)
+  val _quintary: Prism[Arities, (Unit, Boolean, String, Int, Double)] =
+    Prism[Arities, (Unit, Boolean, String, Int, Double)] {
+      case Quintary(u, b, s, i, f) => Some((u, b, s, i, f))
+      case _                       => None
+    } (Quintary.tupled)
+
+
   checkAll("apply Prism", PrismTests(_right[String, Int]))
 
   checkAll("prism.asTraversal", OptionalTests(_right[String, Int].asOptional))
@@ -40,4 +64,11 @@ class PrismSpec extends MonocleSuite {
     _5s.getOption(List(5,5,5))     shouldEqual Some(List((), (), ()))
   }
 
+  test("apply") {
+    _nullary() shouldEqual Nullary()
+    _unary(3) shouldEqual Unary(3)
+    _binary("foo", 7) shouldEqual Binary("foo", 7)
+    _quintary((), true, "bar", 13, 0.4) shouldEqual
+      Quintary((), true, "bar", 13, 0.4)
+  }
 }


### PR DESCRIPTION
We use this at @slamdata to avoid having to deal with various inference problems caused by subtyping. @wemrysi came up with this approach.