### PR TITLE
Prism.partial uses a PartialFunction rather than Option.

### DIFF
--- a/core/shared/src/main/scala/monocle/Prism.scala
+++ b/core/shared/src/main/scala/monocle/Prism.scala
@@ -293,8 +293,7 @@ object Prism {
         _getOption(s)
     }
 
-  /** Create a Prism using a partial function rather than Option.
-    */
+  /** Create a Prism using a partial function rather than Option. */
   def partial[S, A](get: PartialFunction[S, A])(reverseGet: A => S): Prism[S, A] =
     Prism[S, A](get.lift)(reverseGet)
 

--- a/core/shared/src/main/scala/monocle/Prism.scala
+++ b/core/shared/src/main/scala/monocle/Prism.scala
@@ -293,6 +293,11 @@ object Prism {
         _getOption(s)
     }
 
+  /** Create a Prism using a partial function rather than Option.
+    */
+  def partial[S, A](get: PartialFunction[S, A])(reverseGet: A => S): Prism[S, A] =
+    Prism[S, A](get.lift)(reverseGet)
+
   /** a [[Prism]] that checks for equality with a given value */
   def only[A](a: A)(implicit A: Equal[A]): Prism[A, Unit] =
     Prism[A, Unit](a2 => if(A.equal(a, a2)) Some(()) else None)(_ => a)

--- a/test/shared/src/test/scala/monocle/PrismSpec.scala
+++ b/test/shared/src/test/scala/monocle/PrismSpec.scala
@@ -8,6 +8,8 @@ import scalaz.std.list._
 class PrismSpec extends MonocleSuite {
 
   def _right[E, A]: Prism[E \/ A, A] = Prism[E \/ A, A](_.toOption)(\/.right)
+  def _pright[E, A]: Prism[E \/ A, A] =
+    Prism.partial[E \/ A, A](Function.unlift(_.toOption))(\/.right)
 
   val _nullary: Prism[Arities, Unit] =
     Prism[Arities, Unit] {
@@ -34,6 +36,7 @@ class PrismSpec extends MonocleSuite {
 
 
   checkAll("apply Prism", PrismTests(_right[String, Int]))
+  checkAll("apply partial Prism", PrismTests(_pright[String, Int]))
 
   checkAll("prism.asTraversal", OptionalTests(_right[String, Int].asOptional))
   checkAll("prism.asTraversal", TraversalTests(_right[String, Int].asTraversal))


### PR DESCRIPTION
A helper for construction of Prisms that shortens their definitions
slightly. Very helpful when you have dozens of them strewn across your
codebase.

We use this a lot at @slamdata. Here’s a recently-added batch: https://github.com/sellout/quasar/blob/modernize-sql-expr/core/src/main/scala/quasar/sql/package.scala#L31