### PR TITLE
Add unapply method to PPrism and PIso.

### DIFF
--- a/core/shared/src/main/scala/monocle/Iso.scala
+++ b/core/shared/src/main/scala/monocle/Iso.scala
@@ -279,6 +279,8 @@ abstract class PIso[S, T, A, B] extends Serializable { self =>
 
   def apply[C, D, E, F, G, H](c: C, d: D, e: E, f: F, g: G, h: H)(implicit ev: (C, D, E, F, G, H) <~< B): T =
     apply(ev((c, d, e, f, g, h)))
+
+  def unapply(obj: S): Some[A] = Some(get(obj))
 }
 
 object PIso extends IsoInstances {

--- a/core/shared/src/main/scala/monocle/Prism.scala
+++ b/core/shared/src/main/scala/monocle/Prism.scala
@@ -253,6 +253,8 @@ abstract class PPrism[S, T, A, B] extends Serializable { self =>
 
   def apply[C, D, E, F, G, H](c: C, d: D, e: E, f: F, g: G, h: H)(implicit ev: (C, D, E, F, G, H) <~< B): T =
     apply(ev((c, d, e, f, g, h)))
+
+  def unapply(obj: S): Option[A] = getOption(obj)
 }
 
 object PPrism extends PrismInstances {

--- a/test/shared/src/test/scala/monocle/IsoSpec.scala
+++ b/test/shared/src/test/scala/monocle/IsoSpec.scala
@@ -84,5 +84,14 @@ class IsoSpec extends MonocleSuite {
     _quintary('x', true, "bar", 13, 0.4) shouldEqual
       Quintary('x', true, "bar", 13, 0.4)
   }
+
+  test("unapply") {
+    (Nullary() match { case _nullary(unit) => unit }) shouldEqual (())
+    (Unary(3) match { case _unary(value) => value * 2 }) shouldEqual 6
+    (Binary("foo", 7) match { case _binary(s, i) => s + i }) shouldEqual "foo7"
+    (Quintary('x', true, "bar", 13, 0.4) match {
+      case _quintary(c, b, s, i, f) => "" + c + b + s + i + f
+    }) shouldEqual "xtruebar130.4"
+  }
 }
 

--- a/test/shared/src/test/scala/monocle/PrismSpec.scala
+++ b/test/shared/src/test/scala/monocle/PrismSpec.scala
@@ -76,10 +76,10 @@ class PrismSpec extends MonocleSuite {
   }
 
   test("unapply") {
-    (Nullary() match { case _nullary(unit) => unit }) shouldEqual (())
-    (Unary(3) match { case _unary(value) => value * 2 }) shouldEqual 6
-    (Binary("foo", 7) match { case _binary(s, i) => s + i }) shouldEqual "foo7"
-    (Quintary('x', true, "bar", 13, 0.4) match {
+    ((Nullary(): Arities) match { case _nullary(unit) => unit }) shouldEqual (())
+    ((Unary(3): Arities) match { case _unary(value) => value * 2 }) shouldEqual 6
+    ((Binary("foo", 7): Arities) match { case _binary(s, i) => s + i }) shouldEqual "foo7"
+    ((Quintary('x', true, "bar", 13, 0.4): Arities) match {
       case _quintary(c, b, s, i, f) => "" + c + b + s + i + f
     }) shouldEqual "xtruebar130.4"
   }

--- a/test/shared/src/test/scala/monocle/PrismSpec.scala
+++ b/test/shared/src/test/scala/monocle/PrismSpec.scala
@@ -74,4 +74,13 @@ class PrismSpec extends MonocleSuite {
     _quintary('x', true, "bar", 13, 0.4) shouldEqual
       Quintary('x', true, "bar", 13, 0.4)
   }
+
+  test("unapply") {
+    (Nullary() match { case _nullary(unit) => unit }) shouldEqual (())
+    (Unary(3) match { case _unary(value) => value * 2 }) shouldEqual 6
+    (Binary("foo", 7) match { case _binary(s, i) => s + i }) shouldEqual "foo7"
+    (Quintary('x', true, "bar", 13, 0.4) match {
+      case _quintary(c, b, s, i, f) => "" + c + b + s + i + f
+    }) shouldEqual "xtruebar130.4"
+  }
 }


### PR DESCRIPTION
Fixes #360.

The goal here is to be able to use arbitrary Prisms and Isos as
apply/unapply objects, making the relationship between apply/unapply
more explicit.