### PR TITLE
Add State syntax for Optional

### DIFF
--- a/example/src/test/scala/monocle/state/StateExample.scala
+++ b/example/src/test/scala/monocle/state/StateExample.scala
@@ -1,6 +1,6 @@
 package monocle.state
 
-import monocle.MonocleSuite
+import monocle.{MonocleSuite, Optional}
 import monocle.macros.GenLens
 
 class StateExample extends MonocleSuite {
@@ -39,6 +39,47 @@ class StateExample extends MonocleSuite {
     } yield i
 
     set20.run(p) shouldEqual ((Person("John", 20), 30))
+  }
+
+  val _oldAge = Optional[Person, Int](p => if (p.age > 50) Some(p.age) else None){ a => _.copy(age = a) }
+  val _coolGuy = Optional[Person, String](p => if (p.name.startsWith("C")) Some(p.name) else None){ n => _.copy(name = n) }
+
+  test("mod for Optional (predicate is false)"){
+    val youngPerson = Person("John", 30)
+    val update = for {
+      i <- _oldAge mod (_ + 1)
+    } yield i
+
+    update.run(youngPerson) shouldEqual ((Person("John", 30), None))
+  }
+
+  test("mod for Optional (predicate is true)"){
+    val oldPerson = Person("John", 100)
+    val update = for {
+      i <- _oldAge mod (_ + 1)
+    } yield i
+
+    update.run(oldPerson) shouldEqual ((Person("John", 101), Some(100)))
+  }
+
+  test("mod for Optional (chaining modifications)"){
+    val oldCoolPerson = Person("Chris", 100)
+    val update = for {
+      _ <- _oldAge mod (_ + 1)
+      x <- _coolGuy mod (_.toLowerCase)
+    } yield x
+
+    update.run(oldCoolPerson) shouldEqual ((Person("chris", 101), Some("Chris")))
+  }
+
+  test("mod for Optional (only some of the modifications are applied)"){
+    val oldCoolPerson = Person("Chris", 30)
+    val update = for {
+      _ <- _oldAge mod (_ + 1)
+      x <- _coolGuy mod (_.toLowerCase)
+    } yield x
+
+    update.run(oldCoolPerson) shouldEqual ((Person("chris", 30), Some("Chris")))
   }
 
 }

--- a/example/src/test/scala/monocle/state/StateExample.scala
+++ b/example/src/test/scala/monocle/state/StateExample.scala
@@ -44,39 +44,39 @@ class StateExample extends MonocleSuite {
   val _oldAge = Optional[Person, Int](p => if (p.age > 50) Some(p.age) else None){ a => _.copy(age = a) }
   val _coolGuy = Optional[Person, String](p => if (p.name.startsWith("C")) Some(p.name) else None){ n => _.copy(name = n) }
 
-  test("mod for Optional (predicate is false)"){
+  test("modo for Optional (predicate is false)"){
     val youngPerson = Person("John", 30)
     val update = for {
-      i <- _oldAge mod (_ + 1)
+      i <- _oldAge modo (_ + 1)
     } yield i
 
     update.run(youngPerson) shouldEqual ((Person("John", 30), None))
   }
 
-  test("mod for Optional (predicate is true)"){
+  test("modo for Optional (predicate is true)"){
     val oldPerson = Person("John", 100)
     val update = for {
-      i <- _oldAge mod (_ + 1)
+      i <- _oldAge modo (_ + 1)
     } yield i
 
     update.run(oldPerson) shouldEqual ((Person("John", 101), Some(100)))
   }
 
-  test("mod for Optional (chaining modifications)"){
+  test("modo for Optional (chaining modifications)"){
     val oldCoolPerson = Person("Chris", 100)
     val update = for {
-      _ <- _oldAge mod (_ + 1)
-      x <- _coolGuy mod (_.toLowerCase)
+      _ <- _oldAge modo (_ + 1)
+      x <- _coolGuy modo (_.toLowerCase)
     } yield x
 
     update.run(oldCoolPerson) shouldEqual ((Person("chris", 101), Some("Chris")))
   }
 
-  test("mod for Optional (only some of the modifications are applied)"){
+  test("modo for Optional (only some of the modifications are applied)"){
     val oldCoolPerson = Person("Chris", 30)
     val update = for {
-      _ <- _oldAge mod (_ + 1)
-      x <- _coolGuy mod (_.toLowerCase)
+      _ <- _oldAge modo (_ + 1)
+      x <- _coolGuy modo (_.toLowerCase)
     } yield x
 
     update.run(oldCoolPerson) shouldEqual ((Person("chris", 30), Some("Chris")))

--- a/state/shared/src/main/scala/monocle/state/All.scala
+++ b/state/shared/src/main/scala/monocle/state/All.scala
@@ -1,3 +1,3 @@
 package monocle.state
 
-object all extends StateLensSyntax
+object all extends StateLensSyntax with StateOptionalSyntax

--- a/state/shared/src/main/scala/monocle/state/StateOptionalSyntax.scala
+++ b/state/shared/src/main/scala/monocle/state/StateOptionalSyntax.scala
@@ -19,10 +19,10 @@ final class StateOptionalOps[S, T, A, B](optional: POptional[S, T, A, B]) {
     toState
 
   /** modify the value viewed through the Optional and return its *old* value, if there was one */
-  def mod(f: A => B): IndexedState[S, T, Option[A]] =
+  def modo(f: A => B): IndexedState[S, T, Option[A]] =
     IndexedState(s => (optional.modify(f)(s), optional.getOption(s)))
 
   /** set the value viewed through the Optional and return its *old* value, if there was one */
-  def assign(b: B): IndexedState[S, T, Option[A]] = mod(_ => b)
+  def assigno(b: B): IndexedState[S, T, Option[A]] = modo(_ => b)
 
 }

--- a/state/shared/src/main/scala/monocle/state/StateOptionalSyntax.scala
+++ b/state/shared/src/main/scala/monocle/state/StateOptionalSyntax.scala
@@ -1,0 +1,28 @@
+package monocle.state
+
+import monocle.POptional
+
+import scalaz.{IndexedState, State}
+
+trait StateOptionalSyntax {
+  implicit def toStateOptionalOps[S, T, A, B](optional: POptional[S, T, A, B]): StateOptionalOps[S, T, A, B] =
+    new StateOptionalOps[S, T, A, B](optional)
+}
+
+final class StateOptionalOps[S, T, A, B](optional: POptional[S, T, A, B]) {
+  /** transforms a POptional into a State */
+  def toState: State[S, Option[A]] =
+    State(s => (s, optional.getOption(s)))
+
+  /** alias for toState */
+  def st: State[S, Option[A]] =
+    toState
+
+  /** modify the value viewed through the Optional and return its *old* value, if there was one */
+  def mod(f: A => B): IndexedState[S, T, Option[A]] =
+    IndexedState(s => (optional.modify(f)(s), optional.getOption(s)))
+
+  /** set the value viewed through the Optional and return its *old* value, if there was one */
+  def assign(b: B): IndexedState[S, T, Option[A]] = mod(_ => b)
+
+}

--- a/test/shared/src/test/scala/monocle/MonocleSuite.scala
+++ b/test/shared/src/test/scala/monocle/MonocleSuite.scala
@@ -3,7 +3,7 @@ package monocle
 import monocle.function.GenericOptics
 import monocle.generic.GenericInstances
 import monocle.refined.RefinedInstances
-import monocle.state.StateLensSyntax
+import monocle.state.{StateLensSyntax, StateOptionalSyntax}
 import monocle.std.StdInstances
 import monocle.syntax.Syntaxes
 import org.scalatest.{FunSuite, Matchers}
@@ -19,3 +19,4 @@ trait MonocleSuite extends FunSuite
                       with RefinedInstances
                       with Syntaxes
                       with StateLensSyntax
+                      with StateOptionalSyntax


### PR DESCRIPTION
Similar to what was already available for Lens.

I'm not sure how useful this is to anyone apart from me, so feel free to reject this PR.

My use case for this is concisely chaining JSON transformations using `JsonPath` in Circe.

e.g. if I have some input JSON


```scala
val inputJson = parse("""
{
  "user": {
    "name": "Chris",
    "age": 31
  },
  "timestamp": 1470326934000
}
""").getOrElse(Json.Null)
```

then I could transform it as follows:

```scala
val transform = for {
  _ <- root.user.name.string mod (_.toLowerCase)
  _ <- root.user.age.int mod (_ + 1)
  x <- root.timestamp.long mod (new DateTime(_).toString)
} yield x

val transformedJson = transform.exec(inputJson)
```