### PR TITLE
fix table rendering in docs

### DIFF
--- a/docs/src/site/_config.yml
+++ b/docs/src/site/_config.yml
@@ -1,5 +1,8 @@
 name: Monocle documentation
 markdown: redcarpet
+redcarpet:
+  extensions:
+    - tables
 highlighter: pygments
 baseurl: /Monocle/
 apidocs: /Monocle/api/

--- a/docs/src/site/css/styles.css
+++ b/docs/src/site/css/styles.css
@@ -68,7 +68,7 @@ pre {
 }
 
 table {
-  width:100%;
+# width:100%;
   border-collapse: collapse;
 }
 


### PR DESCRIPTION
my local preview
```bash
$ cd docs/src/site/
$ jekyll serve
```
Before:
<img width="1080" alt="2016-10-20 4 28 11" src="https://cloud.githubusercontent.com/assets/2589034/19534167/b81e4e16-967d-11e6-9102-828998e4378e.png">
After:
<img width="1080" alt="2016-10-20 4 28 25" src="https://cloud.githubusercontent.com/assets/2589034/19534173/bbef6b24-967d-11e6-8f48-517fa598d7dd.png">


