### PR TITLE
Refactor typeclass

### DIFF
--- a/core/shared/src/main/scala/monocle/function/At.scala
+++ b/core/shared/src/main/scala/monocle/function/At.scala
@@ -16,6 +16,13 @@ abstract class At[S, I, A] extends Serializable {
   def at(i: I): Lens[S, A]
 }
 
+trait AtFunctions {
+  def at[S, I, A](i: I)(implicit ev: At[S, I, A]): Lens[S, A] = ev.at(i)
+
+  /** delete a value associated with a key in a Map-like container */
+  def remove[S, I, A](i: I)(s: S)(implicit ev: At[S, I, Option[A]]): S =
+  ev.at(i).set(None)(s)
+}
 
 object At extends AtFunctions {
   def apply[S, I, A](get: I => S => A)(set: I => A => S => S): At[S, I, A] =
@@ -25,15 +32,33 @@ object At extends AtFunctions {
 
   /** lift an instance of [[At]] using an [[Iso]] */
   def fromIso[S, U, I, A](iso: Iso[S, U])(implicit ev: At[U, I, A]): At[S, I, A] = new At[S, I, A]{
-    override def at(i: I): Lens[S, A] =
+    def at(i: I): Lens[S, A] =
       iso composeLens ev.at(i)
   }
-}
 
-trait AtFunctions {
-  def at[S, I, A](i: I)(implicit ev: At[S, I, A]): Lens[S, A] = ev.at(i)
+  /************************************************************************************************/
+  /** Std instances                                                                               */
+  /************************************************************************************************/
 
-  /** delete a value associated with a key in a Map-like container */
-  def remove[S, I, A](i: I)(s: S)(implicit ev: At[S, I, Option[A]]): S =
-    ev.at(i).set(None)(s)
+  implicit def atMap[K, V]: At[Map[K, V], K, Option[V]] = new At[Map[K, V], K, Option[V]]{
+    def at(i: K) = Lens{m: Map[K, V] => m.get(i)}(optV => map => optV.fold(map - i)(v => map + (i -> v)))
+  }
+
+  implicit def atSet[A]: At[Set[A], A, Boolean] = new At[Set[A], A, Boolean] {
+    def at(a: A) = Lens[Set[A], Boolean](_.contains(a))(b => set => if(b) set + a else set - a)
+  }
+
+  /************************************************************************************************/
+  /** Scalaz instances                                                                            */
+  /************************************************************************************************/
+
+  import scalaz.{==>>, ISet, Order}
+
+  implicit def atIMap[K: Order, V]: At[K ==>> V, K, Option[V]] = new At[K ==>> V, K, Option[V]]{
+    def at(i: K) = Lens{m: ==>>[K, V] => m.lookup(i)}(optV => map => optV.fold(map - i)(v => map + (i -> v)))
+  }
+
+  implicit def atISet[A: Order]: At[ISet[A], A, Boolean] = new At[ISet[A], A, Boolean] {
+    def at(a: A) = Lens[ISet[A], Boolean](_.member(a))(b => set => if(b) set insert a else set delete a)
+  }
 }

--- a/core/shared/src/main/scala/monocle/function/At.scala
+++ b/core/shared/src/main/scala/monocle/function/At.scala
@@ -21,7 +21,7 @@ trait AtFunctions {
 
   /** delete a value associated with a key in a Map-like container */
   def remove[S, I, A](i: I)(s: S)(implicit ev: At[S, I, Option[A]]): S =
-  ev.at(i).set(None)(s)
+    ev.at(i).set(None)(s)
 }
 
 object At extends AtFunctions {

--- a/core/shared/src/main/scala/monocle/function/At.scala
+++ b/core/shared/src/main/scala/monocle/function/At.scala
@@ -12,7 +12,7 @@ import scala.annotation.implicitNotFound
  */
 @implicitNotFound("Could not find an instance of At[${S},${I},${A}], please check Monocle instance location policy to " +
   "find out which import is necessary")
-trait At[S, I, A] extends Serializable {
+abstract class At[S, I, A] extends Serializable {
   def at(i: I): Lens[S, A]
 }
 

--- a/core/shared/src/main/scala/monocle/function/Cons.scala
+++ b/core/shared/src/main/scala/monocle/function/Cons.scala
@@ -13,7 +13,7 @@ import scala.annotation.implicitNotFound
  */
 @implicitNotFound("Could not find an instance of Cons[${S},${A}], please check Monocle instance location policy to " +
   "find out which import is necessary")
-trait Cons[S, A] extends Serializable {
+abstract class Cons[S, A] extends Serializable {
   def cons: Prism[S, (A, S)]
 
   def headOption: Optional[S, A] = cons composeLens first

--- a/core/shared/src/main/scala/monocle/function/Cons.scala
+++ b/core/shared/src/main/scala/monocle/function/Cons.scala
@@ -5,6 +5,7 @@ import monocle.std.tuple2._
 import monocle.{Iso, Optional, Prism}
 
 import scala.annotation.implicitNotFound
+import scalaz.{ICons, INil}
 
 /**
  * Typeclass that defines a [[Prism]] between an `S` and its head `A` and tail `S`
@@ -20,15 +21,6 @@ abstract class Cons[S, A] extends Serializable {
   def tailOption: Optional[S, S] = cons composeLens second
 }
 
-object Cons extends ConsFunctions {
-  /** lift an instance of [[Cons]] using an [[Iso]] */
-  def fromIso[S, A, B](iso: Iso[S, A])(implicit ev: Cons[A, B]): Cons[S, B] = new Cons[S, B] {
-    override def cons: Prism[S, (B, S)] =
-      iso composePrism ev.cons composeIso iso.reverse.second
-  }
-}
-
-
 trait ConsFunctions {
   final def cons[S, A](implicit ev: Cons[S, A]): Prism[S, (A, S)] = ev.cons
 
@@ -37,9 +29,63 @@ trait ConsFunctions {
 
   /** append an element to the head */
   final def _cons[S, A](head: A, tail: S)(implicit ev: Cons[S, A]): S =
-    ev.cons.reverseGet((head, tail))
+  ev.cons.reverseGet((head, tail))
 
   /** deconstruct an S between its head and tail */
   final def _uncons[S, A](s: S)(implicit ev: Cons[S, A]): Option[(A, S)] =
-    ev.cons.getOption(s)
+  ev.cons.getOption(s)
+}
+
+object Cons extends ConsFunctions {
+  /** lift an instance of [[Cons]] using an [[Iso]] */
+  def fromIso[S, A, B](iso: Iso[S, A])(implicit ev: Cons[A, B]): Cons[S, B] = new Cons[S, B] {
+    def cons: Prism[S, (B, S)] =
+      iso composePrism ev.cons composeIso iso.reverse.second
+  }
+
+  /************************************************************************************************/
+  /** Std instances                                                                               */
+  /************************************************************************************************/
+  import scala.collection.immutable.Stream.#::
+
+  implicit def listCons[A]: Cons[List[A], A] = new Cons[List[A], A]{
+    def cons = Prism[List[A], (A, List[A])]{
+      case Nil     => None
+      case x :: xs => Some((x, xs))
+    }{ case (a, s) => a :: s }
+  }
+
+  implicit def streamCons[A]: Cons[Stream[A], A] = new Cons[Stream[A], A]{
+    def cons = Prism[Stream[A], (A, Stream[A])]{
+      case scala.collection.immutable.Stream.Empty => None
+      case x #:: xs => Some((x, xs))
+    }{ case (a, s) => a #:: s }
+  }
+
+  implicit val stringCons: Cons[String, Char] = new Cons[String, Char] {
+    def cons =
+      Prism[String, (Char, String)](s =>
+        if(s.isEmpty) None else Some((s.head, s.tail))
+      ){ case (h, t) => h + t }
+  }
+
+  implicit def vectorCons[A]: Cons[Vector[A], A] = new Cons[Vector[A], A]{
+    def cons = Prism[Vector[A], (A, Vector[A])]{
+      case Vector() => None
+      case x +: xs  => Some((x, xs))
+    }{ case (a, s) => a +: s }
+  }
+
+  /************************************************************************************************/
+  /** Scalaz instances                                                                            */
+  /************************************************************************************************/
+
+  import scalaz.IList
+
+  implicit def iListCons[A]: Cons[IList[A], A] = new Cons[IList[A], A]{
+    def cons = Prism[IList[A], (A, IList[A])]{
+      case INil()       => None
+      case ICons(x, xs) => Some((x, xs))
+    }{ case (a, s) => ICons(a, s) }
+  }
 }

--- a/core/shared/src/main/scala/monocle/function/Cons.scala
+++ b/core/shared/src/main/scala/monocle/function/Cons.scala
@@ -39,7 +39,7 @@ trait ConsFunctions {
 object Cons extends ConsFunctions {
   /** lift an instance of [[Cons]] using an [[Iso]] */
   def fromIso[S, A, B](iso: Iso[S, A])(implicit ev: Cons[A, B]): Cons[S, B] = new Cons[S, B] {
-    def cons: Prism[S, (B, S)] =
+    val cons: Prism[S, (B, S)] =
       iso composePrism ev.cons composeIso iso.reverse.second
   }
 
@@ -49,28 +49,28 @@ object Cons extends ConsFunctions {
   import scala.collection.immutable.Stream.#::
 
   implicit def listCons[A]: Cons[List[A], A] = new Cons[List[A], A]{
-    def cons = Prism[List[A], (A, List[A])]{
+    val cons = Prism[List[A], (A, List[A])]{
       case Nil     => None
       case x :: xs => Some((x, xs))
     }{ case (a, s) => a :: s }
   }
 
   implicit def streamCons[A]: Cons[Stream[A], A] = new Cons[Stream[A], A]{
-    def cons = Prism[Stream[A], (A, Stream[A])]{
+    val cons = Prism[Stream[A], (A, Stream[A])]{
       case scala.collection.immutable.Stream.Empty => None
       case x #:: xs => Some((x, xs))
     }{ case (a, s) => a #:: s }
   }
 
   implicit val stringCons: Cons[String, Char] = new Cons[String, Char] {
-    def cons =
+    val cons =
       Prism[String, (Char, String)](s =>
         if(s.isEmpty) None else Some((s.head, s.tail))
       ){ case (h, t) => h + t }
   }
 
   implicit def vectorCons[A]: Cons[Vector[A], A] = new Cons[Vector[A], A]{
-    def cons = Prism[Vector[A], (A, Vector[A])]{
+    val cons = Prism[Vector[A], (A, Vector[A])]{
       case Vector() => None
       case x +: xs  => Some((x, xs))
     }{ case (a, s) => a +: s }
@@ -83,7 +83,7 @@ object Cons extends ConsFunctions {
   import scalaz.IList
 
   implicit def iListCons[A]: Cons[IList[A], A] = new Cons[IList[A], A]{
-    def cons = Prism[IList[A], (A, IList[A])]{
+    val cons = Prism[IList[A], (A, IList[A])]{
       case INil()       => None
       case ICons(x, xs) => Some((x, xs))
     }{ case (a, s) => ICons(a, s) }

--- a/core/shared/src/main/scala/monocle/function/Cons1.scala
+++ b/core/shared/src/main/scala/monocle/function/Cons1.scala
@@ -40,7 +40,7 @@ trait Cons1Functions {
 object Cons1 extends Cons1Functions {
   /** lift an instance of [[Cons1]] using an [[Iso]] */
   def fromIso[S, A, H, T](iso: Iso[S, A])(implicit ev: Cons1[A, H, T]): Cons1[S, H, T] = new Cons1[S, H, T] {
-    def cons1: Iso[S, (H, T)] =
+    val cons1: Iso[S, (H, T)] =
       iso composeIso ev.cons1
   }
 
@@ -49,19 +49,19 @@ object Cons1 extends Cons1Functions {
   /************************************************************************************************/
 
   implicit def tuple2Cons1[A1, A2]: Cons1[(A1, A2), A1, A2] = new Cons1[(A1, A2), A1, A2] {
-    def cons1 = Iso[(A1, A2), (A1, A2)](identity)(identity)
+    val cons1 = Iso[(A1, A2), (A1, A2)](identity)(identity)
   }
 
   implicit def tuple3Cons1[A1, A2, A3]: Cons1[(A1, A2, A3), A1, (A2, A3)] = new Cons1[(A1, A2, A3), A1, (A2, A3)] {
-    def cons1 = Iso[(A1, A2, A3), (A1, (A2, A3))](t => (t._1, (t._2, t._3))){ case (h, t) => (h, t._1, t._2) }
+    val cons1 = Iso[(A1, A2, A3), (A1, (A2, A3))](t => (t._1, (t._2, t._3))){ case (h, t) => (h, t._1, t._2) }
   }
 
   implicit def tuple4Cons1[A1, A2, A3, A4]: Cons1[(A1, A2, A3, A4), A1, (A2, A3, A4)] = new Cons1[(A1, A2, A3, A4), A1, (A2, A3, A4)]{
-    def cons1 = Iso[(A1, A2, A3, A4), (A1, (A2, A3, A4))](t => (t._1, (t._2, t._3, t._4))){ case (h, t) => (h, t._1, t._2, t._3) }
+    val cons1 = Iso[(A1, A2, A3, A4), (A1, (A2, A3, A4))](t => (t._1, (t._2, t._3, t._4))){ case (h, t) => (h, t._1, t._2, t._3) }
   }
 
   implicit def tuple5Cons1[A1, A2, A3, A4, A5]: Cons1[(A1, A2, A3, A4, A5), A1, (A2, A3, A4, A5)] = new Cons1[(A1, A2, A3, A4, A5), A1, (A2, A3, A4, A5)]{
-    def cons1 = Iso[(A1, A2, A3, A4, A5), (A1, (A2, A3, A4, A5))](t => (t._1, (t._2, t._3, t._4, t._5))){ case (h, t) => (h, t._1, t._2, t._3, t._4) }
+    val cons1 = Iso[(A1, A2, A3, A4, A5), (A1, (A2, A3, A4, A5))](t => (t._1, (t._2, t._3, t._4, t._5))){ case (h, t) => (h, t._1, t._2, t._3, t._4) }
   }
 
   implicit def tuple5Snoc1[A1, A2, A3, A4, A5]: Snoc1[(A1, A2, A3, A4, A5), (A1, A2, A3, A4), A5] = new Snoc1[(A1, A2, A3, A4, A5), (A1, A2, A3, A4), A5]{
@@ -69,7 +69,7 @@ object Cons1 extends Cons1Functions {
   }
 
   implicit def tuple6Cons1[A1, A2, A3, A4, A5, A6]: Cons1[(A1, A2, A3, A4, A5, A6), A1, (A2, A3, A4, A5, A6)] = new Cons1[(A1, A2, A3, A4, A5, A6), A1, (A2, A3, A4, A5, A6)]{
-    def cons1 = Iso[(A1, A2, A3, A4, A5, A6), (A1, (A2, A3, A4, A5, A6))](t => (t._1, (t._2, t._3, t._4, t._5, t._6))){ case (h, t) => (h, t._1, t._2, t._3, t._4, t._5) }
+    val cons1 = Iso[(A1, A2, A3, A4, A5, A6), (A1, (A2, A3, A4, A5, A6))](t => (t._1, (t._2, t._3, t._4, t._5, t._6))){ case (h, t) => (h, t._1, t._2, t._3, t._4, t._5) }
   }
 
   /************************************************************************************************/
@@ -80,7 +80,7 @@ object Cons1 extends Cons1Functions {
   implicit def cofreeCons1[S[_], A]: Cons1[Cofree[S, A], A, S[Cofree[S, A]]] =
     new Cons1[Cofree[S, A], A, S[Cofree[S, A]]] {
 
-      def cons1: Iso[Cofree[S, A], (A, S[Cofree[S, A]])]  =
+      val cons1: Iso[Cofree[S, A], (A, S[Cofree[S, A]])]  =
         Iso((c: Cofree[S, A]) => (c.head, c.tail)){ case (h, t) => Cofree(h, t) }
 
       /** Overridden to prevent forcing evaluation of the `tail` when we're only
@@ -91,11 +91,11 @@ object Cons1 extends Cons1Functions {
 
   implicit def nelCons1[A]: Cons1[NonEmptyList[A], A, IList[A]] =
     new Cons1[NonEmptyList[A],A,IList[A]]{
-      def cons1: Iso[NonEmptyList[A], (A, IList[A])] =
+      val cons1: Iso[NonEmptyList[A], (A, IList[A])] =
         Iso((nel: NonEmptyList[A]) => (nel.head,nel.tail)){case (h,t) => NonEmptyList.nel(h, t)}
     }
 
   implicit def oneAndCons1[T[_], A]: Cons1[OneAnd[T, A], A, T[A]] = new Cons1[OneAnd[T, A], A, T[A]] {
-    def cons1 = Iso[OneAnd[T, A], (A, T[A])](o => (o.head, o.tail)){ case (h, t) => OneAnd(h, t)}
+    val cons1 = Iso[OneAnd[T, A], (A, T[A])](o => (o.head, o.tail)){ case (h, t) => OneAnd(h, t)}
   }
 }

--- a/core/shared/src/main/scala/monocle/function/Cons1.scala
+++ b/core/shared/src/main/scala/monocle/function/Cons1.scala
@@ -15,7 +15,7 @@ import scala.annotation.implicitNotFound
  */
 @implicitNotFound("Could not find an instance of Cons1[${S}, ${H}, ${T}], please check Monocle instance location policy to " +
   "find out which import is necessary")
-trait Cons1[S, H, T] extends Serializable {
+abstract class Cons1[S, H, T] extends Serializable {
   def cons1: Iso[S, (H, T)]
 
   def head: Lens[S, H] = cons1 composeLens first

--- a/core/shared/src/main/scala/monocle/function/Cons1.scala
+++ b/core/shared/src/main/scala/monocle/function/Cons1.scala
@@ -22,16 +22,6 @@ abstract class Cons1[S, H, T] extends Serializable {
   def tail: Lens[S, T] = cons1 composeLens second
 }
 
-
-object Cons1 extends Cons1Functions {
-  /** lift an instance of [[Cons1]] using an [[Iso]] */
-  def fromIso[S, A, H, T](iso: Iso[S, A])(implicit ev: Cons1[A, H, T]): Cons1[S, H, T] = new Cons1[S, H, T] {
-    override def cons1: Iso[S, (H, T)] =
-      iso composeIso ev.cons1
-  }
-}
-
-
 trait Cons1Functions {
   final def cons1[S, H, T](implicit ev: Cons1[S, H, T]): Iso[S, (H, T)] = ev.cons1
 
@@ -40,9 +30,72 @@ trait Cons1Functions {
 
   /** append an element to the head */
   final def _cons1[S, H, T](head: H, tail: T)(implicit ev: Cons1[S, H, T]): S =
-    ev.cons1.reverseGet((head, tail))
+  ev.cons1.reverseGet((head, tail))
 
   /** deconstruct an S between its head and tail */
   final def _uncons1[S, H, T](s: S)(implicit ev: Cons1[S, H, T]): (H, T) =
-    ev.cons1.get(s)
+  ev.cons1.get(s)
+}
+
+object Cons1 extends Cons1Functions {
+  /** lift an instance of [[Cons1]] using an [[Iso]] */
+  def fromIso[S, A, H, T](iso: Iso[S, A])(implicit ev: Cons1[A, H, T]): Cons1[S, H, T] = new Cons1[S, H, T] {
+    def cons1: Iso[S, (H, T)] =
+      iso composeIso ev.cons1
+  }
+
+  /************************************************************************************************/
+  /** Std instances                                                                               */
+  /************************************************************************************************/
+
+  implicit def tuple2Cons1[A1, A2]: Cons1[(A1, A2), A1, A2] = new Cons1[(A1, A2), A1, A2] {
+    def cons1 = Iso[(A1, A2), (A1, A2)](identity)(identity)
+  }
+
+  implicit def tuple3Cons1[A1, A2, A3]: Cons1[(A1, A2, A3), A1, (A2, A3)] = new Cons1[(A1, A2, A3), A1, (A2, A3)] {
+    def cons1 = Iso[(A1, A2, A3), (A1, (A2, A3))](t => (t._1, (t._2, t._3))){ case (h, t) => (h, t._1, t._2) }
+  }
+
+  implicit def tuple4Cons1[A1, A2, A3, A4]: Cons1[(A1, A2, A3, A4), A1, (A2, A3, A4)] = new Cons1[(A1, A2, A3, A4), A1, (A2, A3, A4)]{
+    def cons1 = Iso[(A1, A2, A3, A4), (A1, (A2, A3, A4))](t => (t._1, (t._2, t._3, t._4))){ case (h, t) => (h, t._1, t._2, t._3) }
+  }
+
+  implicit def tuple5Cons1[A1, A2, A3, A4, A5]: Cons1[(A1, A2, A3, A4, A5), A1, (A2, A3, A4, A5)] = new Cons1[(A1, A2, A3, A4, A5), A1, (A2, A3, A4, A5)]{
+    def cons1 = Iso[(A1, A2, A3, A4, A5), (A1, (A2, A3, A4, A5))](t => (t._1, (t._2, t._3, t._4, t._5))){ case (h, t) => (h, t._1, t._2, t._3, t._4) }
+  }
+
+  implicit def tuple5Snoc1[A1, A2, A3, A4, A5]: Snoc1[(A1, A2, A3, A4, A5), (A1, A2, A3, A4), A5] = new Snoc1[(A1, A2, A3, A4, A5), (A1, A2, A3, A4), A5]{
+    def snoc1 = Iso[(A1, A2, A3, A4, A5), ((A1, A2, A3, A4), A5)](t => ((t._1, t._2, t._3, t._4), t._5)){ case (i, l) => (i._1, i._2, i._3, i._4, l) }
+  }
+
+  implicit def tuple6Cons1[A1, A2, A3, A4, A5, A6]: Cons1[(A1, A2, A3, A4, A5, A6), A1, (A2, A3, A4, A5, A6)] = new Cons1[(A1, A2, A3, A4, A5, A6), A1, (A2, A3, A4, A5, A6)]{
+    def cons1 = Iso[(A1, A2, A3, A4, A5, A6), (A1, (A2, A3, A4, A5, A6))](t => (t._1, (t._2, t._3, t._4, t._5, t._6))){ case (h, t) => (h, t._1, t._2, t._3, t._4, t._5) }
+  }
+
+  /************************************************************************************************/
+  /** Scalaz instances                                                                            */
+  /************************************************************************************************/
+  import scalaz.{Cofree, IList, NonEmptyList, OneAnd}
+
+  implicit def cofreeCons1[S[_], A]: Cons1[Cofree[S, A], A, S[Cofree[S, A]]] =
+    new Cons1[Cofree[S, A], A, S[Cofree[S, A]]] {
+
+      def cons1: Iso[Cofree[S, A], (A, S[Cofree[S, A]])]  =
+        Iso((c: Cofree[S, A]) => (c.head, c.tail)){ case (h, t) => Cofree(h, t) }
+
+      /** Overridden to prevent forcing evaluation of the `tail` when we're only
+        * interested in using the `head` */
+      override def head: Lens[Cofree[S, A], A] =
+      Lens((c: Cofree[S, A]) => c.head)(h => c => Cofree.delay(h, c.tail))
+    }
+
+  implicit def nelCons1[A]: Cons1[NonEmptyList[A], A, IList[A]] =
+    new Cons1[NonEmptyList[A],A,IList[A]]{
+      def cons1: Iso[NonEmptyList[A], (A, IList[A])] =
+        Iso((nel: NonEmptyList[A]) => (nel.head,nel.tail)){case (h,t) => NonEmptyList.nel(h, t)}
+    }
+
+  implicit def oneAndCons1[T[_], A]: Cons1[OneAnd[T, A], A, T[A]] = new Cons1[OneAnd[T, A], A, T[A]] {
+    def cons1 = Iso[OneAnd[T, A], (A, T[A])](o => (o.head, o.tail)){ case (h, t) => OneAnd(h, t)}
+  }
 }

--- a/core/shared/src/main/scala/monocle/function/Curry.scala
+++ b/core/shared/src/main/scala/monocle/function/Curry.scala
@@ -18,24 +18,24 @@ trait CurryFunctions {
 
 object Curry extends CurryFunctions with CurryInstances {
   implicit def curry5[A, B, C, D, E, F] = new Curry[(A, B, C, D, E) => F, A => B => C => D => E => F] {
-    def curry = Iso((_: (A, B, C, D, E) => F).curried)(f => Function.uncurried(f))
+    val curry = Iso((_: (A, B, C, D, E) => F).curried)(f => Function.uncurried(f))
   }
 }
 
 trait CurryInstances extends CurryInstances1 {
   implicit def curry4[A, B, C, D, E] = new Curry[(A, B, C, D) => E, A => B => C => D => E] {
-    def curry = Iso((_: (A, B, C, D) => E).curried)(f => Function.uncurried(f))
+    val curry = Iso((_: (A, B, C, D) => E).curried)(f => Function.uncurried(f))
   }
 }
 
 trait CurryInstances1 extends CurryInstances2 {
   implicit def curry3[A, B, C, D] = new Curry[(A, B, C) => D, A => B => C => D] {
-    def curry = Iso((_: (A, B, C) => D).curried)(f => Function.uncurried(f))
+    val curry = Iso((_: (A, B, C) => D).curried)(f => Function.uncurried(f))
   }
 }
 
 trait CurryInstances2 {
   implicit def curry2[A, B, C] = new Curry[(A, B) => C, A => B => C] {
-    def curry = Iso((_: (A, B) => C).curried)(f => Function.uncurried(f))
+    val curry = Iso((_: (A, B) => C).curried)(f => Function.uncurried(f))
   }
 }

--- a/core/shared/src/main/scala/monocle/function/Curry.scala
+++ b/core/shared/src/main/scala/monocle/function/Curry.scala
@@ -5,7 +5,7 @@ import scala.annotation.implicitNotFound
 
 @implicitNotFound("Could not find an instance of Curry[${F},${G}], please check Monocle instance location policy to " +
   "find out which import is necessary")
-trait Curry[F, G] extends Serializable {
+abstract class Curry[F, G] extends Serializable {
 
   /** curry: ((A,B,...,Z) => Res) <=> (A => B => ... => Z => Res) */
   def curry: Iso[F, G]

--- a/core/shared/src/main/scala/monocle/function/Curry.scala
+++ b/core/shared/src/main/scala/monocle/function/Curry.scala
@@ -11,12 +11,31 @@ abstract class Curry[F, G] extends Serializable {
   def curry: Iso[F, G]
 }
 
-object Curry extends CurryFunctions
-
 trait CurryFunctions {
-
   def curry[F, G](implicit ev: Curry[F, G]): Iso[F, G] = ev.curry
-
   def uncurry[F, G](implicit ev: Curry[F, G]): Iso[G, F] = curry.reverse
+}
 
+object Curry extends CurryFunctions with CurryInstances {
+  implicit def curry5[A, B, C, D, E, F] = new Curry[(A, B, C, D, E) => F, A => B => C => D => E => F] {
+    def curry = Iso((_: (A, B, C, D, E) => F).curried)(f => Function.uncurried(f))
+  }
+}
+
+trait CurryInstances extends CurryInstances1 {
+  implicit def curry4[A, B, C, D, E] = new Curry[(A, B, C, D) => E, A => B => C => D => E] {
+    def curry = Iso((_: (A, B, C, D) => E).curried)(f => Function.uncurried(f))
+  }
+}
+
+trait CurryInstances1 extends CurryInstances2 {
+  implicit def curry3[A, B, C, D] = new Curry[(A, B, C) => D, A => B => C => D] {
+    def curry = Iso((_: (A, B, C) => D).curried)(f => Function.uncurried(f))
+  }
+}
+
+trait CurryInstances2 {
+  implicit def curry2[A, B, C] = new Curry[(A, B) => C, A => B => C] {
+    def curry = Iso((_: (A, B) => C).curried)(f => Function.uncurried(f))
+  }
 }

--- a/core/shared/src/main/scala/monocle/function/Each.scala
+++ b/core/shared/src/main/scala/monocle/function/Each.scala
@@ -3,7 +3,7 @@ package monocle.function
 import monocle.{Iso, PTraversal, Traversal}
 
 import scala.annotation.implicitNotFound
-import scalaz.Traverse
+import scalaz.{Applicative, Traverse}
 
 /**
  * Typeclass that defines a [[Traversal]] from a monomorphic container `S` to all of its elements of type `A`
@@ -16,14 +16,6 @@ abstract class Each[S, A] extends Serializable {
   def each: Traversal[S, A]
 }
 
-object Each extends EachFunctions {
-  /** lift an instance of [[Each]] using an [[Iso]] */
-  def fromIso[S, A, B](iso: Iso[S, A])(implicit ev: Each[A, B]): Each[S, B] = new Each[S, B] {
-    override def each: Traversal[S, B] =
-      iso composeTraversal ev.each
-  }
-}
-
 
 trait EachFunctions {
   def each[S, A](implicit ev: Each[S, A]): Traversal[S, A] = ev.each
@@ -31,4 +23,87 @@ trait EachFunctions {
   def traverseEach[S[_]: Traverse, A]: Each[S[A], A] = new Each[S[A], A] {
     def each = PTraversal.fromTraverse[S, A, A]
   }
+}
+
+object Each extends EachFunctions {
+  /** lift an instance of [[Each]] using an [[Iso]] */
+  def fromIso[S, A, B](iso: Iso[S, A])(implicit ev: Each[A, B]): Each[S, B] = new Each[S, B] {
+    def each: Traversal[S, B] =
+      iso composeTraversal ev.each
+  }
+
+  /************************************************************************************************/
+  /** Std instances                                                                               */
+  /************************************************************************************************/
+  import scalaz.std.list._
+  import scalaz.std.map._
+  import scalaz.std.stream._
+  import scalaz.std.vector._
+
+  implicit def listEach[A]: Each[List[A], A] = traverseEach
+
+  implicit def mapEach[K, V]: Each[Map[K, V], V] = traverseEach[Map[K, ?], V]
+
+  implicit def optEach[A]: Each[Option[A], A] = new Each[Option[A], A] {
+    def each = monocle.std.option.some.asTraversal
+  }
+
+  implicit def streamEach[A]: Each[Stream[A], A] = traverseEach
+
+  implicit val stringEach: Each[String, Char] = new Each[String, Char] {
+    def each = monocle.std.string.stringToList composeTraversal Each.each[List[Char], Char]
+  }
+
+  implicit def tuple1Each[A]: Each[Tuple1[A], A] = new Each[Tuple1[A], A] {
+    def each = monocle.std.tuple1.tuple1Iso[A].asTraversal
+  }
+
+  implicit def tuple2Each[A]: Each[(A, A), A] = new Each[(A, A), A] {
+    def each = PTraversal.apply2[(A, A), (A, A), A, A](_._1,_._2)((b1, b2, _) => (b1, b2))
+  }
+
+  implicit def tuple3Each[A]: Each[(A, A, A), A] = new Each[(A, A, A), A] {
+    def each = PTraversal.apply3[(A, A, A), (A, A, A), A, A](_._1,_._2,_._3)((b1, b2, b3, _) => (b1, b2, b3))
+  }
+
+  implicit def tuple4Each[A]: Each[(A, A, A, A), A] = new Each[(A, A, A, A), A] {
+    def each = PTraversal.apply4[(A, A, A, A), (A, A, A, A), A, A](_._1,_._2,_._3,_._4)((b1, b2, b3, b4, _) => (b1, b2, b3, b4))
+  }
+
+  implicit def tuple5Each[A]: Each[(A, A, A, A, A), A] = new Each[(A, A, A, A, A), A] {
+    def each = PTraversal.apply5[(A, A, A, A, A), (A, A, A, A, A), A, A](_._1,_._2,_._3,_._4,_._5)((b1, b2, b3, b4, b5, _) => (b1, b2, b3, b4, b5))
+  }
+
+  implicit def tuple6Each[A]: Each[(A, A, A, A, A, A), A] = new Each[(A, A, A, A, A, A), A] {
+    def each = PTraversal.apply6[(A, A, A, A, A, A), (A, A, A, A, A, A), A, A](_._1,_._2,_._3,_._4,_._5, _._6)((b1, b2, b3, b4, b5, b6, _) => (b1, b2, b3, b4, b5, b6))
+  }
+
+  implicit def vectorEach[A]: Each[Vector[A], A] = traverseEach
+
+  /************************************************************************************************/
+  /** Scalaz instances                                                                            */
+  /************************************************************************************************/
+  import scalaz.{==>>, Cofree, IList, Maybe, NonEmptyList, OneAnd, Tree}
+
+  implicit def cofreeEach[S[_]: Traverse, A]: Each[Cofree[S, A], A] = traverseEach[Cofree[S, ?], A]
+
+  implicit def iListEach[A]: Each[IList[A], A] = traverseEach
+
+  implicit def iMapEach[K, V]: Each[K ==>> V, V] = traverseEach[K ==>> ?, V]
+
+  implicit def maybeEach[A]: Each[Maybe[A], A] = new Each[Maybe[A], A]{
+    def each = monocle.std.maybe.just.asTraversal
+  }
+
+  implicit def nelEach[A]: Each[NonEmptyList[A], A] = traverseEach
+
+  implicit def oneAndEach[T[_], A](implicit ev: Each[T[A], A]): Each[OneAnd[T, A], A] =
+    new Each[OneAnd[T, A], A]{
+      def each = new Traversal[OneAnd[T, A], A]{
+        def modifyF[F[_]: Applicative](f: A => F[A])(s: OneAnd[T, A]): F[OneAnd[T, A]] =
+          Applicative[F].apply2(f(s.head), ev.each.modifyF(f)(s.tail))((head, tail) => new OneAnd(head, tail))
+      }
+    }
+
+  implicit def treeEach[A]: Each[Tree[A], A] = traverseEach
 }

--- a/core/shared/src/main/scala/monocle/function/Each.scala
+++ b/core/shared/src/main/scala/monocle/function/Each.scala
@@ -12,7 +12,7 @@ import scalaz.Traverse
  */
 @implicitNotFound("Could not find an instance of Each[${S},${A}], please check Monocle instance location policy to " +
   "find out which import is necessary")
-trait Each[S, A] extends Serializable {
+abstract class Each[S, A] extends Serializable {
   def each: Traversal[S, A]
 }
 

--- a/core/shared/src/main/scala/monocle/function/Each.scala
+++ b/core/shared/src/main/scala/monocle/function/Each.scala
@@ -45,7 +45,7 @@ object Each extends EachFunctions {
   implicit def mapEach[K, V]: Each[Map[K, V], V] = traverseEach[Map[K, ?], V]
 
   implicit def optEach[A]: Each[Option[A], A] = new Each[Option[A], A] {
-    val each = monocle.std.option.some.asTraversal
+    def each = monocle.std.option.some[A].asTraversal
   }
 
   implicit def streamEach[A]: Each[Stream[A], A] = traverseEach

--- a/core/shared/src/main/scala/monocle/function/Each.scala
+++ b/core/shared/src/main/scala/monocle/function/Each.scala
@@ -28,7 +28,7 @@ trait EachFunctions {
 object Each extends EachFunctions {
   /** lift an instance of [[Each]] using an [[Iso]] */
   def fromIso[S, A, B](iso: Iso[S, A])(implicit ev: Each[A, B]): Each[S, B] = new Each[S, B] {
-    def each: Traversal[S, B] =
+    val each: Traversal[S, B] =
       iso composeTraversal ev.each
   }
 
@@ -45,37 +45,37 @@ object Each extends EachFunctions {
   implicit def mapEach[K, V]: Each[Map[K, V], V] = traverseEach[Map[K, ?], V]
 
   implicit def optEach[A]: Each[Option[A], A] = new Each[Option[A], A] {
-    def each = monocle.std.option.some.asTraversal
+    val each = monocle.std.option.some.asTraversal
   }
 
   implicit def streamEach[A]: Each[Stream[A], A] = traverseEach
 
   implicit val stringEach: Each[String, Char] = new Each[String, Char] {
-    def each = monocle.std.string.stringToList composeTraversal Each.each[List[Char], Char]
+    val each = monocle.std.string.stringToList composeTraversal Each.each[List[Char], Char]
   }
 
   implicit def tuple1Each[A]: Each[Tuple1[A], A] = new Each[Tuple1[A], A] {
-    def each = monocle.std.tuple1.tuple1Iso[A].asTraversal
+    val each = monocle.std.tuple1.tuple1Iso[A].asTraversal
   }
 
   implicit def tuple2Each[A]: Each[(A, A), A] = new Each[(A, A), A] {
-    def each = PTraversal.apply2[(A, A), (A, A), A, A](_._1,_._2)((b1, b2, _) => (b1, b2))
+    val each = PTraversal.apply2[(A, A), (A, A), A, A](_._1,_._2)((b1, b2, _) => (b1, b2))
   }
 
   implicit def tuple3Each[A]: Each[(A, A, A), A] = new Each[(A, A, A), A] {
-    def each = PTraversal.apply3[(A, A, A), (A, A, A), A, A](_._1,_._2,_._3)((b1, b2, b3, _) => (b1, b2, b3))
+    val each = PTraversal.apply3[(A, A, A), (A, A, A), A, A](_._1,_._2,_._3)((b1, b2, b3, _) => (b1, b2, b3))
   }
 
   implicit def tuple4Each[A]: Each[(A, A, A, A), A] = new Each[(A, A, A, A), A] {
-    def each = PTraversal.apply4[(A, A, A, A), (A, A, A, A), A, A](_._1,_._2,_._3,_._4)((b1, b2, b3, b4, _) => (b1, b2, b3, b4))
+    val each = PTraversal.apply4[(A, A, A, A), (A, A, A, A), A, A](_._1,_._2,_._3,_._4)((b1, b2, b3, b4, _) => (b1, b2, b3, b4))
   }
 
   implicit def tuple5Each[A]: Each[(A, A, A, A, A), A] = new Each[(A, A, A, A, A), A] {
-    def each = PTraversal.apply5[(A, A, A, A, A), (A, A, A, A, A), A, A](_._1,_._2,_._3,_._4,_._5)((b1, b2, b3, b4, b5, _) => (b1, b2, b3, b4, b5))
+    val each = PTraversal.apply5[(A, A, A, A, A), (A, A, A, A, A), A, A](_._1,_._2,_._3,_._4,_._5)((b1, b2, b3, b4, b5, _) => (b1, b2, b3, b4, b5))
   }
 
   implicit def tuple6Each[A]: Each[(A, A, A, A, A, A), A] = new Each[(A, A, A, A, A, A), A] {
-    def each = PTraversal.apply6[(A, A, A, A, A, A), (A, A, A, A, A, A), A, A](_._1,_._2,_._3,_._4,_._5, _._6)((b1, b2, b3, b4, b5, b6, _) => (b1, b2, b3, b4, b5, b6))
+    val each = PTraversal.apply6[(A, A, A, A, A, A), (A, A, A, A, A, A), A, A](_._1,_._2,_._3,_._4,_._5, _._6)((b1, b2, b3, b4, b5, b6, _) => (b1, b2, b3, b4, b5, b6))
   }
 
   implicit def vectorEach[A]: Each[Vector[A], A] = traverseEach
@@ -99,7 +99,7 @@ object Each extends EachFunctions {
 
   implicit def oneAndEach[T[_], A](implicit ev: Each[T[A], A]): Each[OneAnd[T, A], A] =
     new Each[OneAnd[T, A], A]{
-      def each = new Traversal[OneAnd[T, A], A]{
+      val each = new Traversal[OneAnd[T, A], A]{
         def modifyF[F[_]: Applicative](f: A => F[A])(s: OneAnd[T, A]): F[OneAnd[T, A]] =
           Applicative[F].apply2(f(s.head), ev.each.modifyF(f)(s.tail))((head, tail) => new OneAnd(head, tail))
       }

--- a/core/shared/src/main/scala/monocle/function/Empty.scala
+++ b/core/shared/src/main/scala/monocle/function/Empty.scala
@@ -28,7 +28,7 @@ trait EmptyFunctions {
 object Empty extends EmptyFunctions {
   /** lift an instance of [[Empty]] using an [[Iso]] */
   def fromIso[S, A](iso: Iso[S, A])(implicit ev: Empty[A]): Empty[S] = new Empty[S] {
-    def empty: Prism[S, Unit] =
+    val empty: Prism[S, Unit] =
       iso composePrism ev.empty
   }
 
@@ -37,31 +37,31 @@ object Empty extends EmptyFunctions {
   /************************************************************************************************/
 
   implicit def listEmpty[A]: Empty[List[A]] = new Empty[List[A]] {
-    def empty = Prism[List[A], Unit](l => if(l.isEmpty) Some(()) else None)(_ => List.empty)
+    val empty = Prism[List[A], Unit](l => if(l.isEmpty) Some(()) else None)(_ => List.empty)
   }
 
   implicit def mapEmpty[K, V]: Empty[Map[K, V]] = new Empty[Map[K, V]] {
-    def empty = Prism[Map[K, V], Unit](m => if(m.isEmpty) Some(()) else None)(_ => Map.empty)
+    val empty = Prism[Map[K, V], Unit](m => if(m.isEmpty) Some(()) else None)(_ => Map.empty)
   }
 
   implicit def optionEmpty[A]: Empty[Option[A]] = new Empty[Option[A]] {
-    def empty = monocle.std.option.none
+    val empty = monocle.std.option.none
   }
 
   implicit def emptySet[A]: Empty[Set[A]] = new Empty[Set[A]] {
-    def empty = Prism[Set[A], Unit](s => if(s.isEmpty) Some(()) else None)(_ => Set.empty[A])
+    val empty = Prism[Set[A], Unit](s => if(s.isEmpty) Some(()) else None)(_ => Set.empty[A])
   }
 
   implicit def streamEmpty[A]: Empty[Stream[A]] = new Empty[Stream[A]] {
-    def empty = Prism[Stream[A], Unit](s => if(s.isEmpty) Some(()) else None)(_ => Stream.empty)
+    val empty = Prism[Stream[A], Unit](s => if(s.isEmpty) Some(()) else None)(_ => Stream.empty)
   }
 
   implicit val stringEmpty: Empty[String] = new Empty[String] {
-    def empty = Prism[String, Unit](s => if(s.isEmpty) Some(()) else None)(_ => "")
+    val empty = Prism[String, Unit](s => if(s.isEmpty) Some(()) else None)(_ => "")
   }
 
   implicit def vectorEmpty[A]: Empty[Vector[A]] = new Empty[Vector[A]] {
-    def empty = Prism[Vector[A], Unit](v => if(v.isEmpty) Some(()) else None)(_ => Vector.empty)
+    val empty = Prism[Vector[A], Unit](v => if(v.isEmpty) Some(()) else None)(_ => Vector.empty)
   }
 
   /************************************************************************************************/

--- a/core/shared/src/main/scala/monocle/function/Empty.scala
+++ b/core/shared/src/main/scala/monocle/function/Empty.scala
@@ -10,7 +10,7 @@ import scala.annotation.implicitNotFound
  */
 @implicitNotFound("Could not find an instance of Empty[${S}], please check Monocle instance location policy to " +
   "find out which import is necessary")
-trait Empty[S] extends Serializable {
+abstract class Empty[S] extends Serializable {
   def empty: Prism[S, Unit]
 }
 

--- a/core/shared/src/main/scala/monocle/function/Empty.scala
+++ b/core/shared/src/main/scala/monocle/function/Empty.scala
@@ -45,7 +45,7 @@ object Empty extends EmptyFunctions {
   }
 
   implicit def optionEmpty[A]: Empty[Option[A]] = new Empty[Option[A]] {
-    val empty = monocle.std.option.none
+    val empty = monocle.std.option.none[A]
   }
 
   implicit def emptySet[A]: Empty[Set[A]] = new Empty[Set[A]] {

--- a/core/shared/src/main/scala/monocle/function/Empty.scala
+++ b/core/shared/src/main/scala/monocle/function/Empty.scala
@@ -14,23 +14,75 @@ abstract class Empty[S] extends Serializable {
   def empty: Prism[S, Unit]
 }
 
-object Empty extends EmptyFunctions {
-  /** lift an instance of [[Empty]] using an [[Iso]] */
-  def fromIso[S, A](iso: Iso[S, A])(implicit ev: Empty[A]): Empty[S] = new Empty[S] {
-    override def empty: Prism[S, Unit] =
-      iso composePrism ev.empty
-  }
-}
-
 trait EmptyFunctions {
-  
   def empty[S](implicit ev: Empty[S]): Prism[S, Unit] =
     ev.empty
-  
+
   def _isEmpty[S](s: S)(implicit ev: Empty[S]): Boolean =
     ev.empty.getOption(s).isDefined
 
   def _empty[S](implicit ev: Empty[S]): S =
     ev.empty.reverseGet(())
-  
+}
+
+object Empty extends EmptyFunctions {
+  /** lift an instance of [[Empty]] using an [[Iso]] */
+  def fromIso[S, A](iso: Iso[S, A])(implicit ev: Empty[A]): Empty[S] = new Empty[S] {
+    def empty: Prism[S, Unit] =
+      iso composePrism ev.empty
+  }
+
+  /************************************************************************************************/
+  /** Std instances                                                                               */
+  /************************************************************************************************/
+
+  implicit def listEmpty[A]: Empty[List[A]] = new Empty[List[A]] {
+    def empty = Prism[List[A], Unit](l => if(l.isEmpty) Some(()) else None)(_ => List.empty)
+  }
+
+  implicit def mapEmpty[K, V]: Empty[Map[K, V]] = new Empty[Map[K, V]] {
+    def empty = Prism[Map[K, V], Unit](m => if(m.isEmpty) Some(()) else None)(_ => Map.empty)
+  }
+
+  implicit def optionEmpty[A]: Empty[Option[A]] = new Empty[Option[A]] {
+    def empty = monocle.std.option.none
+  }
+
+  implicit def emptySet[A]: Empty[Set[A]] = new Empty[Set[A]] {
+    def empty = Prism[Set[A], Unit](s => if(s.isEmpty) Some(()) else None)(_ => Set.empty[A])
+  }
+
+  implicit def streamEmpty[A]: Empty[Stream[A]] = new Empty[Stream[A]] {
+    def empty = Prism[Stream[A], Unit](s => if(s.isEmpty) Some(()) else None)(_ => Stream.empty)
+  }
+
+  implicit val stringEmpty: Empty[String] = new Empty[String] {
+    def empty = Prism[String, Unit](s => if(s.isEmpty) Some(()) else None)(_ => "")
+  }
+
+  implicit def vectorEmpty[A]: Empty[Vector[A]] = new Empty[Vector[A]] {
+    def empty = Prism[Vector[A], Unit](v => if(v.isEmpty) Some(()) else None)(_ => Vector.empty)
+  }
+
+  /************************************************************************************************/
+  /** Scalaz instances                                                                            */
+  /************************************************************************************************/
+  import monocle.std.maybe.nothing
+  import scalaz.{==>>, IList, ISet, Maybe}
+
+  implicit def iListEmpty[A]: Empty[IList[A]] = new Empty[IList[A]] {
+    def empty = Prism[IList[A], Unit](l => if(l.isEmpty) Some(()) else None)(_ => IList.empty)
+  }
+
+  implicit def iMapEmpty[K, V]: Empty[K ==>> V] = new Empty[K ==>> V] {
+    def empty = Prism[K ==>> V, Unit](m => if(m.isEmpty) Some(()) else None)(_ => ==>>.empty)
+  }
+
+  implicit def emptyISet[A]: Empty[ISet[A]] = new Empty[ISet[A]] {
+    def empty = Prism[ISet[A], Unit](s => if(s.isEmpty) Some(()) else None)(_ => ISet.empty[A])
+  }
+
+  implicit def maybeEmpty[A]: Empty[Maybe[A]] = new Empty[Maybe[A]]{
+    def empty = nothing
+  }
 }

--- a/core/shared/src/main/scala/monocle/function/Field1.scala
+++ b/core/shared/src/main/scala/monocle/function/Field1.scala
@@ -22,8 +22,7 @@ trait Field1Functions {
 object Field1 extends Field1Functions {
   /** lift an instance of [[Field1]] using an [[Iso]] */
   def fromIso[S, A, B](iso: Iso[S, A])(implicit ev: Field1[A, B]): Field1[S, B] = new Field1[S, B] {
-    def first: Lens[S, B] =
-      iso composeLens ev.first
+    val first: Lens[S, B] = iso composeLens ev.first
   }
 
   /************************************************************************************************/
@@ -31,27 +30,27 @@ object Field1 extends Field1Functions {
   /************************************************************************************************/
 
   implicit def tuple1Field1[A]: Field1[Tuple1[A], A] = new Field1[Tuple1[A], A] {
-    def first = Lens((_: Tuple1[A])._1)(a => _ => Tuple1(a))
+    val first = Lens((_: Tuple1[A])._1)(a => _ => Tuple1(a))
   }
 
   implicit def tuple2Field1[A1, A2]: Field1[(A1, A2), A1] = new Field1[(A1, A2), A1] {
-    def first = Lens((_: (A1, A2))._1)(a => t => t.copy(_1 = a))
+    val first = Lens((_: (A1, A2))._1)(a => t => t.copy(_1 = a))
   }
 
   implicit def tuple3Field1[A1, A2, A3]: Field1[(A1, A2, A3), A1] = new Field1[(A1, A2, A3), A1] {
-    def first = Lens((_: (A1, A2, A3))._1)(a => t => t.copy(_1 = a))
+    val first = Lens((_: (A1, A2, A3))._1)(a => t => t.copy(_1 = a))
   }
 
   implicit def tuple4Field1[A1, A2, A3, A4]: Field1[(A1, A2, A3, A4), A1] = new Field1[(A1, A2, A3, A4), A1] {
-    def first = Lens((_: (A1, A2, A3, A4))._1)(a => t => t.copy(_1 = a))
+    val first = Lens((_: (A1, A2, A3, A4))._1)(a => t => t.copy(_1 = a))
   }
 
   implicit def tuple5Field1[A1, A2, A3, A4, A5]: Field1[(A1, A2, A3, A4, A5), A1] = new Field1[(A1, A2, A3, A4, A5), A1] {
-    def first = Lens((_: (A1, A2, A3, A4, A5))._1)(a => t => t.copy(_1 = a))
+    val first = Lens((_: (A1, A2, A3, A4, A5))._1)(a => t => t.copy(_1 = a))
   }
 
   implicit def tuple6Field1[A1, A2, A3, A4, A5, A6]: Field1[(A1, A2, A3, A4, A5, A6), A1] = new Field1[(A1, A2, A3, A4, A5, A6), A1] {
-    def first = Lens((_: (A1, A2, A3, A4, A5, A6))._1)(a => t => t.copy(_1 = a))
+    val first = Lens((_: (A1, A2, A3, A4, A5, A6))._1)(a => t => t.copy(_1 = a))
   }
 
   /************************************************************************************************/
@@ -60,6 +59,6 @@ object Field1 extends Field1Functions {
   import scalaz.OneAnd
 
   implicit def oneAndField1[T[_], A]: Field1[OneAnd[T, A], A] = new Field1[OneAnd[T, A], A]{
-    def first = Lens[OneAnd[T, A], A](_.head)(a => oneAnd => oneAnd.copy(head = a))
+    val first = Lens[OneAnd[T, A], A](_.head)(a => oneAnd => oneAnd.copy(head = a))
   }
 }

--- a/core/shared/src/main/scala/monocle/function/Field1.scala
+++ b/core/shared/src/main/scala/monocle/function/Field1.scala
@@ -15,14 +15,51 @@ abstract class Field1[S, A] extends Serializable {
   def first: Lens[S, A]
 }
 
+trait Field1Functions {
+  def first[S, A](implicit ev: Field1[S, A]): Lens[S, A] = ev.first
+}
+
 object Field1 extends Field1Functions {
   /** lift an instance of [[Field1]] using an [[Iso]] */
   def fromIso[S, A, B](iso: Iso[S, A])(implicit ev: Field1[A, B]): Field1[S, B] = new Field1[S, B] {
-    override def first: Lens[S, B] =
+    def first: Lens[S, B] =
       iso composeLens ev.first
   }
-}
 
-trait Field1Functions {
-  def first[S, A](implicit ev: Field1[S, A]): Lens[S, A] = ev.first
+  /************************************************************************************************/
+  /** Std instances                                                                               */
+  /************************************************************************************************/
+
+  implicit def tuple1Field1[A]: Field1[Tuple1[A], A] = new Field1[Tuple1[A], A] {
+    def first = Lens((_: Tuple1[A])._1)(a => _ => Tuple1(a))
+  }
+
+  implicit def tuple2Field1[A1, A2]: Field1[(A1, A2), A1] = new Field1[(A1, A2), A1] {
+    def first = Lens((_: (A1, A2))._1)(a => t => t.copy(_1 = a))
+  }
+
+  implicit def tuple3Field1[A1, A2, A3]: Field1[(A1, A2, A3), A1] = new Field1[(A1, A2, A3), A1] {
+    def first = Lens((_: (A1, A2, A3))._1)(a => t => t.copy(_1 = a))
+  }
+
+  implicit def tuple4Field1[A1, A2, A3, A4]: Field1[(A1, A2, A3, A4), A1] = new Field1[(A1, A2, A3, A4), A1] {
+    def first = Lens((_: (A1, A2, A3, A4))._1)(a => t => t.copy(_1 = a))
+  }
+
+  implicit def tuple5Field1[A1, A2, A3, A4, A5]: Field1[(A1, A2, A3, A4, A5), A1] = new Field1[(A1, A2, A3, A4, A5), A1] {
+    def first = Lens((_: (A1, A2, A3, A4, A5))._1)(a => t => t.copy(_1 = a))
+  }
+
+  implicit def tuple6Field1[A1, A2, A3, A4, A5, A6]: Field1[(A1, A2, A3, A4, A5, A6), A1] = new Field1[(A1, A2, A3, A4, A5, A6), A1] {
+    def first = Lens((_: (A1, A2, A3, A4, A5, A6))._1)(a => t => t.copy(_1 = a))
+  }
+
+  /************************************************************************************************/
+  /** Scalaz instances                                                                            */
+  /************************************************************************************************/
+  import scalaz.OneAnd
+
+  implicit def oneAndField1[T[_], A]: Field1[OneAnd[T, A], A] = new Field1[OneAnd[T, A], A]{
+    def first = Lens[OneAnd[T, A], A](_.head)(a => oneAnd => oneAnd.copy(head = a))
+  }
 }

--- a/core/shared/src/main/scala/monocle/function/Field1.scala
+++ b/core/shared/src/main/scala/monocle/function/Field1.scala
@@ -11,7 +11,7 @@ import scala.annotation.implicitNotFound
  */
 @implicitNotFound("Could not find an instance of Field1[${S},${A}], please check Monocle instance location policy to " +
   "find out which import is necessary")
-trait Field1[S, A] extends Serializable {
+abstract class Field1[S, A] extends Serializable {
   def first: Lens[S, A]
 }
 

--- a/core/shared/src/main/scala/monocle/function/Field2.scala
+++ b/core/shared/src/main/scala/monocle/function/Field2.scala
@@ -15,14 +15,38 @@ abstract class Field2[S, A] extends Serializable {
   def second: Lens[S, A]
 }
 
+trait Field2Functions {
+  def second[S, A](implicit ev: Field2[S, A]): Lens[S, A] = ev.second
+}
+
 object Field2 extends Field2Functions {
   /** lift an instance of [[Field2]] using an [[Iso]] */
   def fromIso[S, A, B](iso: Iso[S, A])(implicit ev: Field2[A, B]): Field2[S, B] = new Field2[S, B] {
     def second: Lens[S, B] =
       iso composeLens ev.second
   }
-}
 
-trait Field2Functions {
-  def second[S, A](implicit ev: Field2[S, A]): Lens[S, A] = ev.second
+  /************************************************************************************************/
+  /** std instances                                                                               */
+  /************************************************************************************************/
+
+  implicit def tuple2Field2[A1, A2]: Field2[(A1, A2), A2]  = new Field2[(A1, A2), A2] {
+    def second = Lens((_: (A1, A2))._2)(a => t => t.copy(_2 = a))
+  }
+
+  implicit def tuple3Field2[A1, A2, A3]: Field2[(A1, A2, A3), A2] = new Field2[(A1, A2, A3), A2] {
+    def second = Lens((_: (A1, A2, A3))._2)(a => t => t.copy(_2 = a))
+  }
+
+  implicit def tuple4Field2[A1, A2, A3, A4]: Field2[(A1, A2, A3, A4), A2] = new Field2[(A1, A2, A3, A4), A2] {
+    def second = Lens((_: (A1, A2, A3, A4))._2)(a => t => t.copy(_2 = a))
+  }
+
+  implicit def tuple5Field2[A1, A2, A3, A4, A5]: Field2[(A1, A2, A3, A4, A5), A2] = new Field2[(A1, A2, A3, A4, A5), A2] {
+    def second = Lens((_: (A1, A2, A3, A4, A5))._2)(a => t => t.copy(_2 = a))
+  }
+
+  implicit def tuple6Field2[A1, A2, A3, A4, A5, A6]: Field2[(A1, A2, A3, A4, A5, A6), A2] = new Field2[(A1, A2, A3, A4, A5, A6), A2] {
+    def second = Lens((_: (A1, A2, A3, A4, A5, A6))._2)(a => t => t.copy(_2 = a))
+  }
 }

--- a/core/shared/src/main/scala/monocle/function/Field2.scala
+++ b/core/shared/src/main/scala/monocle/function/Field2.scala
@@ -11,7 +11,7 @@ import scala.annotation.implicitNotFound
  */
 @implicitNotFound("Could not find an instance of Field2[${S},${A}], please check Monocle instance location policy to " +
   "find out which import is necessary")
-trait Field2[S, A] extends Serializable {
+abstract class Field2[S, A] extends Serializable {
   def second: Lens[S, A]
 }
 

--- a/core/shared/src/main/scala/monocle/function/Field2.scala
+++ b/core/shared/src/main/scala/monocle/function/Field2.scala
@@ -22,8 +22,7 @@ trait Field2Functions {
 object Field2 extends Field2Functions {
   /** lift an instance of [[Field2]] using an [[Iso]] */
   def fromIso[S, A, B](iso: Iso[S, A])(implicit ev: Field2[A, B]): Field2[S, B] = new Field2[S, B] {
-    def second: Lens[S, B] =
-      iso composeLens ev.second
+    val second: Lens[S, B] = iso composeLens ev.second
   }
 
   /************************************************************************************************/
@@ -31,22 +30,22 @@ object Field2 extends Field2Functions {
   /************************************************************************************************/
 
   implicit def tuple2Field2[A1, A2]: Field2[(A1, A2), A2]  = new Field2[(A1, A2), A2] {
-    def second = Lens((_: (A1, A2))._2)(a => t => t.copy(_2 = a))
+    val second = Lens((_: (A1, A2))._2)(a => t => t.copy(_2 = a))
   }
 
   implicit def tuple3Field2[A1, A2, A3]: Field2[(A1, A2, A3), A2] = new Field2[(A1, A2, A3), A2] {
-    def second = Lens((_: (A1, A2, A3))._2)(a => t => t.copy(_2 = a))
+    val second = Lens((_: (A1, A2, A3))._2)(a => t => t.copy(_2 = a))
   }
 
   implicit def tuple4Field2[A1, A2, A3, A4]: Field2[(A1, A2, A3, A4), A2] = new Field2[(A1, A2, A3, A4), A2] {
-    def second = Lens((_: (A1, A2, A3, A4))._2)(a => t => t.copy(_2 = a))
+    val second = Lens((_: (A1, A2, A3, A4))._2)(a => t => t.copy(_2 = a))
   }
 
   implicit def tuple5Field2[A1, A2, A3, A4, A5]: Field2[(A1, A2, A3, A4, A5), A2] = new Field2[(A1, A2, A3, A4, A5), A2] {
-    def second = Lens((_: (A1, A2, A3, A4, A5))._2)(a => t => t.copy(_2 = a))
+    val second = Lens((_: (A1, A2, A3, A4, A5))._2)(a => t => t.copy(_2 = a))
   }
 
   implicit def tuple6Field2[A1, A2, A3, A4, A5, A6]: Field2[(A1, A2, A3, A4, A5, A6), A2] = new Field2[(A1, A2, A3, A4, A5, A6), A2] {
-    def second = Lens((_: (A1, A2, A3, A4, A5, A6))._2)(a => t => t.copy(_2 = a))
+    val second = Lens((_: (A1, A2, A3, A4, A5, A6))._2)(a => t => t.copy(_2 = a))
   }
 }

--- a/core/shared/src/main/scala/monocle/function/Field3.scala
+++ b/core/shared/src/main/scala/monocle/function/Field3.scala
@@ -15,14 +15,34 @@ abstract class Field3[S, A] extends Serializable {
   def third: Lens[S, A]
 }
 
+trait Field3Functions {
+  def third[S, A](implicit ev: Field3[S, A]): Lens[S, A] = ev.third
+}
+
 object Field3 extends Field3Functions {
   /** lift an instance of [[Field3]] using an [[Iso]] */
   def fromIso[S, A, B](iso: Iso[S, A])(implicit ev: Field3[A, B]): Field3[S, B] = new Field3[S, B] {
-    override def third: Lens[S, B] =
+    def third: Lens[S, B] =
       iso composeLens ev.third
   }
-}
 
-trait Field3Functions {
-  def third[S, A](implicit ev: Field3[S, A]): Lens[S, A] = ev.third
+  /************************************************************************************************/
+  /** Std instances                                                                               */
+  /************************************************************************************************/
+
+  implicit def tuple3Field3[A1, A2, A3]: Field3[(A1, A2, A3), A3] = new Field3[(A1, A2, A3), A3] {
+    def third = Lens((_: (A1, A2, A3))._3)(a => t => t.copy(_3 = a))
+  }
+
+  implicit def tuple4Field3[A1, A2, A3, A4]: Field3[(A1, A2, A3, A4), A3]  = new Field3[(A1, A2, A3, A4), A3] {
+    def third = Lens((_: (A1, A2, A3, A4))._3)(a => t => t.copy(_3 = a))
+  }
+
+  implicit def tuple5Field3[A1, A2, A3, A4, A5]: Field3[(A1, A2, A3, A4, A5), A3] = new Field3[(A1, A2, A3, A4, A5), A3] {
+    def third = Lens((_: (A1, A2, A3, A4, A5))._3)(a => t => t.copy(_3 = a))
+  }
+
+  implicit def tuple6Field3[A1, A2, A3, A4, A5, A6]: Field3[(A1, A2, A3, A4, A5, A6), A3] = new Field3[(A1, A2, A3, A4, A5, A6), A3] {
+    def third = Lens((_: (A1, A2, A3, A4, A5, A6))._3)(a => t => t.copy(_3 = a))
+  }
 }

--- a/core/shared/src/main/scala/monocle/function/Field3.scala
+++ b/core/shared/src/main/scala/monocle/function/Field3.scala
@@ -11,7 +11,7 @@ import scala.annotation.implicitNotFound
  */
 @implicitNotFound("Could not find an instance of Field3[${S},${A}], please check Monocle instance location policy to " +
   "find out which import is necessary")
-trait Field3[S, A] extends Serializable {
+abstract class Field3[S, A] extends Serializable {
   def third: Lens[S, A]
 }
 

--- a/core/shared/src/main/scala/monocle/function/Field3.scala
+++ b/core/shared/src/main/scala/monocle/function/Field3.scala
@@ -22,8 +22,7 @@ trait Field3Functions {
 object Field3 extends Field3Functions {
   /** lift an instance of [[Field3]] using an [[Iso]] */
   def fromIso[S, A, B](iso: Iso[S, A])(implicit ev: Field3[A, B]): Field3[S, B] = new Field3[S, B] {
-    def third: Lens[S, B] =
-      iso composeLens ev.third
+    val third: Lens[S, B] = iso composeLens ev.third
   }
 
   /************************************************************************************************/
@@ -31,18 +30,18 @@ object Field3 extends Field3Functions {
   /************************************************************************************************/
 
   implicit def tuple3Field3[A1, A2, A3]: Field3[(A1, A2, A3), A3] = new Field3[(A1, A2, A3), A3] {
-    def third = Lens((_: (A1, A2, A3))._3)(a => t => t.copy(_3 = a))
+    val third = Lens((_: (A1, A2, A3))._3)(a => t => t.copy(_3 = a))
   }
 
   implicit def tuple4Field3[A1, A2, A3, A4]: Field3[(A1, A2, A3, A4), A3]  = new Field3[(A1, A2, A3, A4), A3] {
-    def third = Lens((_: (A1, A2, A3, A4))._3)(a => t => t.copy(_3 = a))
+    val third = Lens((_: (A1, A2, A3, A4))._3)(a => t => t.copy(_3 = a))
   }
 
   implicit def tuple5Field3[A1, A2, A3, A4, A5]: Field3[(A1, A2, A3, A4, A5), A3] = new Field3[(A1, A2, A3, A4, A5), A3] {
-    def third = Lens((_: (A1, A2, A3, A4, A5))._3)(a => t => t.copy(_3 = a))
+    val third = Lens((_: (A1, A2, A3, A4, A5))._3)(a => t => t.copy(_3 = a))
   }
 
   implicit def tuple6Field3[A1, A2, A3, A4, A5, A6]: Field3[(A1, A2, A3, A4, A5, A6), A3] = new Field3[(A1, A2, A3, A4, A5, A6), A3] {
-    def third = Lens((_: (A1, A2, A3, A4, A5, A6))._3)(a => t => t.copy(_3 = a))
+    val third = Lens((_: (A1, A2, A3, A4, A5, A6))._3)(a => t => t.copy(_3 = a))
   }
 }

--- a/core/shared/src/main/scala/monocle/function/Field4.scala
+++ b/core/shared/src/main/scala/monocle/function/Field4.scala
@@ -22,8 +22,7 @@ trait Field4Functions {
 object Field4 extends Field4Functions {
   /** lift an instance of [[Field4]] using an [[Iso]] */
   def fromIso[S, A, B](iso: Iso[S, A])(implicit ev: Field4[A, B]): Field4[S, B] = new Field4[S, B] {
-    def fourth: Lens[S, B] =
-      iso composeLens ev.fourth
+    val fourth: Lens[S, B] = iso composeLens ev.fourth
   }
 
   /************************************************************************************************/
@@ -31,14 +30,14 @@ object Field4 extends Field4Functions {
   /************************************************************************************************/
 
   implicit def tuple4Field4[A1, A2, A3, A4]: Field4[(A1, A2, A3, A4), A4] = new Field4[(A1, A2, A3, A4), A4] {
-    def fourth = Lens((_: (A1, A2, A3, A4))._4)(a => t => t.copy(_4 = a))
+    val fourth = Lens((_: (A1, A2, A3, A4))._4)(a => t => t.copy(_4 = a))
   }
 
   implicit def tuple5Field4[A1, A2, A3, A4, A5]: Field4[(A1, A2, A3, A4, A5), A4] = new Field4[(A1, A2, A3, A4, A5), A4] {
-    def fourth = Lens((_: (A1, A2, A3, A4, A5))._4)(a => t => t.copy(_4 = a))
+    val fourth = Lens((_: (A1, A2, A3, A4, A5))._4)(a => t => t.copy(_4 = a))
   }
 
   implicit def tuple6Field4[A1, A2, A3, A4, A5, A6]: Field4[(A1, A2, A3, A4, A5, A6), A4] = new Field4[(A1, A2, A3, A4, A5, A6), A4] {
-    def fourth = Lens((_: (A1, A2, A3, A4, A5, A6))._4)(a => t => t.copy(_4 = a))
+    val fourth = Lens((_: (A1, A2, A3, A4, A5, A6))._4)(a => t => t.copy(_4 = a))
   }
 }

--- a/core/shared/src/main/scala/monocle/function/Field4.scala
+++ b/core/shared/src/main/scala/monocle/function/Field4.scala
@@ -11,7 +11,7 @@ import scala.annotation.implicitNotFound
  */
 @implicitNotFound("Could not find an instance of Field4[${S},${A}], please check Monocle instance location policy to " +
   "find out which import is necessary")
-trait Field4[S, A] extends Serializable {
+abstract class Field4[S, A] extends Serializable {
   def fourth: Lens[S, A]
 }
 

--- a/core/shared/src/main/scala/monocle/function/Field4.scala
+++ b/core/shared/src/main/scala/monocle/function/Field4.scala
@@ -15,14 +15,30 @@ abstract class Field4[S, A] extends Serializable {
   def fourth: Lens[S, A]
 }
 
+trait Field4Functions {
+  def fourth[S, A](implicit ev: Field4[S, A]): Lens[S, A] = ev.fourth
+}
+
 object Field4 extends Field4Functions {
   /** lift an instance of [[Field4]] using an [[Iso]] */
   def fromIso[S, A, B](iso: Iso[S, A])(implicit ev: Field4[A, B]): Field4[S, B] = new Field4[S, B] {
-    override def fourth: Lens[S, B] =
+    def fourth: Lens[S, B] =
       iso composeLens ev.fourth
   }
-}
 
-trait Field4Functions {
-  def fourth[S, A](implicit ev: Field4[S, A]): Lens[S, A] = ev.fourth
+  /************************************************************************************************/
+  /** Std instances                                                                               */
+  /************************************************************************************************/
+
+  implicit def tuple4Field4[A1, A2, A3, A4]: Field4[(A1, A2, A3, A4), A4] = new Field4[(A1, A2, A3, A4), A4] {
+    def fourth = Lens((_: (A1, A2, A3, A4))._4)(a => t => t.copy(_4 = a))
+  }
+
+  implicit def tuple5Field4[A1, A2, A3, A4, A5]: Field4[(A1, A2, A3, A4, A5), A4] = new Field4[(A1, A2, A3, A4, A5), A4] {
+    def fourth = Lens((_: (A1, A2, A3, A4, A5))._4)(a => t => t.copy(_4 = a))
+  }
+
+  implicit def tuple6Field4[A1, A2, A3, A4, A5, A6]: Field4[(A1, A2, A3, A4, A5, A6), A4] = new Field4[(A1, A2, A3, A4, A5, A6), A4] {
+    def fourth = Lens((_: (A1, A2, A3, A4, A5, A6))._4)(a => t => t.copy(_4 = a))
+  }
 }

--- a/core/shared/src/main/scala/monocle/function/Field5.scala
+++ b/core/shared/src/main/scala/monocle/function/Field5.scala
@@ -11,7 +11,7 @@ import scala.annotation.implicitNotFound
  */
 @implicitNotFound("Could not find an instance of Field5[${S},${A}], please check Monocle instance location policy to " +
   "find out which import is necessary")
-trait Field5[S, A] extends Serializable {
+abstract class Field5[S, A] extends Serializable {
   def fifth: Lens[S, A]
 }
 

--- a/core/shared/src/main/scala/monocle/function/Field5.scala
+++ b/core/shared/src/main/scala/monocle/function/Field5.scala
@@ -15,14 +15,26 @@ abstract class Field5[S, A] extends Serializable {
   def fifth: Lens[S, A]
 }
 
-object Field5 extends Field5Functions {
-  /** lift an instance of [[Field5]] using an [[Iso]] */
-  def fromIso[S, A, B](iso: Iso[S, A])(implicit ev: Field5[A, B]): Field5[S, B] = new Field5[S, B] {
-    override def fifth: Lens[S, B] =
-      iso composeLens ev.fifth
-  }
-}
-
 trait Field5Functions {
   def fifth[S, A](implicit ev: Field5[S, A]): Lens[S, A] = ev.fifth
+}
+
+object Field5 extends Field5Functions{
+  /** lift an instance of [[Field5]] using an [[Iso]] */
+  def fromIso[S, A, B](iso: Iso[S, A])(implicit ev: Field5[A, B]): Field5[S, B] = new Field5[S, B] {
+    def fifth: Lens[S, B] =
+      iso composeLens ev.fifth
+  }
+
+  /************************************************************************************************/
+  /** Std instances                                                                               */
+  /************************************************************************************************/
+
+  implicit def tuple5Field5[A1, A2, A3, A4, A5]: Field5[(A1, A2, A3, A4, A5), A5] = new Field5[(A1, A2, A3, A4, A5), A5] {
+    def fifth = Lens((_: (A1, A2, A3, A4, A5))._5)(a => t => t.copy(_5 = a))
+  }
+
+  implicit def tuple6Field5[A1, A2, A3, A4, A5, A6]: Field5[(A1, A2, A3, A4, A5, A6), A5] = new Field5[(A1, A2, A3, A4, A5, A6), A5] {
+    def fifth = Lens((_: (A1, A2, A3, A4, A5, A6))._5)(a => t => t.copy(_5 = a))
+  }
 }

--- a/core/shared/src/main/scala/monocle/function/Field5.scala
+++ b/core/shared/src/main/scala/monocle/function/Field5.scala
@@ -22,8 +22,7 @@ trait Field5Functions {
 object Field5 extends Field5Functions{
   /** lift an instance of [[Field5]] using an [[Iso]] */
   def fromIso[S, A, B](iso: Iso[S, A])(implicit ev: Field5[A, B]): Field5[S, B] = new Field5[S, B] {
-    def fifth: Lens[S, B] =
-      iso composeLens ev.fifth
+    val fifth: Lens[S, B] = iso composeLens ev.fifth
   }
 
   /************************************************************************************************/
@@ -31,10 +30,10 @@ object Field5 extends Field5Functions{
   /************************************************************************************************/
 
   implicit def tuple5Field5[A1, A2, A3, A4, A5]: Field5[(A1, A2, A3, A4, A5), A5] = new Field5[(A1, A2, A3, A4, A5), A5] {
-    def fifth = Lens((_: (A1, A2, A3, A4, A5))._5)(a => t => t.copy(_5 = a))
+    val fifth = Lens((_: (A1, A2, A3, A4, A5))._5)(a => t => t.copy(_5 = a))
   }
 
   implicit def tuple6Field5[A1, A2, A3, A4, A5, A6]: Field5[(A1, A2, A3, A4, A5, A6), A5] = new Field5[(A1, A2, A3, A4, A5, A6), A5] {
-    def fifth = Lens((_: (A1, A2, A3, A4, A5, A6))._5)(a => t => t.copy(_5 = a))
+    val fifth = Lens((_: (A1, A2, A3, A4, A5, A6))._5)(a => t => t.copy(_5 = a))
   }
 }

--- a/core/shared/src/main/scala/monocle/function/Field6.scala
+++ b/core/shared/src/main/scala/monocle/function/Field6.scala
@@ -15,14 +15,22 @@ abstract class Field6[S, A] extends Serializable {
   def sixth: Lens[S, A]
 }
 
-object Field6 extends Field6Functions {
-  /** lift an instance of [[Field6]] using an [[Iso]] */
-  def fromIso[S, A, B](iso: Iso[S, A])(implicit ev: Field6[A, B]): Field6[S, B] = new Field6[S, B] {
-    override def sixth: Lens[S, B] =
-      iso composeLens ev.sixth
-  }
-}
-
 trait Field6Functions {
   def sixth[S, A](implicit ev: Field6[S, A]): Lens[S, A] = ev.sixth
+}
+
+object Field6 extends Field6Functions{
+  /** lift an instance of [[Field6]] using an [[Iso]] */
+  def fromIso[S, A, B](iso: Iso[S, A])(implicit ev: Field6[A, B]): Field6[S, B] = new Field6[S, B] {
+    def sixth: Lens[S, B] =
+      iso composeLens ev.sixth
+  }
+
+  /************************************************************************************************/
+  /** Std instances                                                                               */
+  /************************************************************************************************/
+
+  implicit def tuple6Field6[A1, A2, A3, A4, A5, A6]: Field6[(A1, A2, A3, A4, A5, A6), A6] = new Field6[(A1, A2, A3, A4, A5, A6), A6] {
+    def sixth = Lens((_: (A1, A2, A3, A4, A5, A6))._6)(a => t => t.copy(_6 = a))
+  }
 }

--- a/core/shared/src/main/scala/monocle/function/Field6.scala
+++ b/core/shared/src/main/scala/monocle/function/Field6.scala
@@ -22,8 +22,7 @@ trait Field6Functions {
 object Field6 extends Field6Functions{
   /** lift an instance of [[Field6]] using an [[Iso]] */
   def fromIso[S, A, B](iso: Iso[S, A])(implicit ev: Field6[A, B]): Field6[S, B] = new Field6[S, B] {
-    def sixth: Lens[S, B] =
-      iso composeLens ev.sixth
+    val sixth: Lens[S, B] = iso composeLens ev.sixth
   }
 
   /************************************************************************************************/
@@ -31,6 +30,6 @@ object Field6 extends Field6Functions{
   /************************************************************************************************/
 
   implicit def tuple6Field6[A1, A2, A3, A4, A5, A6]: Field6[(A1, A2, A3, A4, A5, A6), A6] = new Field6[(A1, A2, A3, A4, A5, A6), A6] {
-    def sixth = Lens((_: (A1, A2, A3, A4, A5, A6))._6)(a => t => t.copy(_6 = a))
+    val sixth = Lens((_: (A1, A2, A3, A4, A5, A6))._6)(a => t => t.copy(_6 = a))
   }
 }

--- a/core/shared/src/main/scala/monocle/function/Field6.scala
+++ b/core/shared/src/main/scala/monocle/function/Field6.scala
@@ -11,7 +11,7 @@ import scala.annotation.implicitNotFound
  */
 @implicitNotFound("Could not find an instance of Field6[${S},${A}], please check Monocle instance location policy to " +
   "find out which import is necessary")
-trait Field6[S, A] extends Serializable {
+abstract class Field6[S, A] extends Serializable {
   def sixth: Lens[S, A]
 }
 

--- a/core/shared/src/main/scala/monocle/function/FilterIndex.scala
+++ b/core/shared/src/main/scala/monocle/function/FilterIndex.scala
@@ -14,7 +14,7 @@ import scalaz.{Applicative, Traverse}
  */
 @implicitNotFound("Could not find an instance of FilterIndex[${S},${I},${A}], please check Monocle instance location policy to " +
   "find out which import is necessary")
-trait FilterIndex[S, I, A] extends Serializable {
+abstract class FilterIndex[S, I, A] extends Serializable {
   def filterIndex(predicate: I => Boolean): Traversal[S, A]
 }
 

--- a/core/shared/src/main/scala/monocle/function/FilterIndex.scala
+++ b/core/shared/src/main/scala/monocle/function/FilterIndex.scala
@@ -18,19 +18,8 @@ abstract class FilterIndex[S, I, A] extends Serializable {
   def filterIndex(predicate: I => Boolean): Traversal[S, A]
 }
 
-object FilterIndex extends FilterIndexFunctions {
-  /** lift an instance of [[FilterIndex]] using an [[Iso]] */
-  def fromIso[S, A, I, B](iso: Iso[S, A])(implicit ev: FilterIndex[A, I, B]): FilterIndex[S, I, B] = new FilterIndex[S, I, B] {
-    override def filterIndex(predicate: I => Boolean): Traversal[S, B] =
-      iso composeTraversal ev.filterIndex(predicate)
-  }
-}
-
 trait FilterIndexFunctions {
-
-  def filterIndex[S, I, A](predicate: I => Boolean)
-                            (implicit ev: FilterIndex[S, I, A]): Traversal[S, A] = ev.filterIndex(predicate)
-
+  def filterIndex[S, I, A](predicate: I => Boolean)(implicit ev: FilterIndex[S, I, A]): Traversal[S, A] = ev.filterIndex(predicate)
 
   def traverseFilterIndex[S[_]: Traverse, A](zipWithIndex: S[A] => S[(A, Int)]): FilterIndex[S[A], Int, A] = new FilterIndex[S[A], Int, A]{
     def filterIndex(predicate: Int => Boolean) = new Traversal[S[A], A] {
@@ -38,5 +27,64 @@ trait FilterIndexFunctions {
         zipWithIndex(s).traverse { case (a, j) => if(predicate(j)) f(a) else Applicative[F].point(a) }
     }
   }
+}
 
+object FilterIndex extends FilterIndexFunctions {
+  /** lift an instance of [[FilterIndex]] using an [[Iso]] */
+  def fromIso[S, A, I, B](iso: Iso[S, A])(implicit ev: FilterIndex[A, I, B]): FilterIndex[S, I, B] = new FilterIndex[S, I, B] {
+    def filterIndex(predicate: I => Boolean): Traversal[S, B] =
+      iso composeTraversal ev.filterIndex(predicate)
+  }
+
+  /************************************************************************************************/
+  /** Std instances                                                                               */
+  /************************************************************************************************/
+  import scalaz.std.list._
+  import scalaz.std.stream._
+  import scalaz.std.vector._
+
+  implicit def listFilterIndex[A]: FilterIndex[List[A], Int, A] =
+    traverseFilterIndex(_.zipWithIndex)
+
+  implicit def mapFilterIndex[K, V]: FilterIndex[Map[K,V], K, V] = new FilterIndex[Map[K, V], K, V] {
+    import scalaz.syntax.applicative._
+    def filterIndex(predicate: K => Boolean) = new Traversal[Map[K, V], V] {
+      def modifyF[F[_]: Applicative](f: V => F[V])(s: Map[K, V]): F[Map[K, V]] =
+        s.toList.traverse{ case (k, v) =>
+          (if(predicate(k)) f(v) else v.point[F]).strengthL(k)
+        }.map(_.toMap)
+    }
+  }
+
+  implicit def streamFilterIndex[A]: FilterIndex[Stream[A], Int, A] =
+    traverseFilterIndex(_.zipWithIndex)
+
+  implicit val stringFilterIndex: FilterIndex[String, Int, Char] = new FilterIndex[String, Int, Char]{
+    def filterIndex(predicate: Int => Boolean) =
+      monocle.std.string.stringToList composeTraversal FilterIndex.filterIndex[List[Char], Int, Char](predicate)
+  }
+
+  implicit def vectorFilterIndex[A]: FilterIndex[Vector[A], Int, A] =
+    traverseFilterIndex(_.zipWithIndex)
+
+  /************************************************************************************************/
+  /** Scalaz instances                                                                            */
+  /************************************************************************************************/
+  import scalaz.{==>>, IList, NonEmptyList, Order}
+
+  implicit def iListFilterIndex[A]: FilterIndex[IList[A], Int, A] =
+    traverseFilterIndex(_.zipWithIndex)
+
+  implicit def iMapFilterIndex[K: Order, V]: FilterIndex[K ==>> V, K, V] = new FilterIndex[K ==>> V, K, V] {
+    import scalaz.syntax.applicative._
+    def filterIndex(predicate: K => Boolean) = new Traversal[K ==>> V, V] {
+      def modifyF[F[_]: Applicative](f: V => F[V])(s: K ==>> V): F[K ==>> V] =
+        s.toList.traverse{ case (k, v) =>
+          (if(predicate(k)) f(v) else v.point[F]).strengthL(k)
+        }.map(==>>.fromList(_))
+    }
+  }
+
+  implicit def nelFilterIndex[A]: FilterIndex[NonEmptyList[A], Int, A] =
+    traverseFilterIndex(_.zipWithIndex)
 }

--- a/core/shared/src/main/scala/monocle/function/Index.scala
+++ b/core/shared/src/main/scala/monocle/function/Index.scala
@@ -3,6 +3,7 @@ package monocle.function
 import monocle.{Iso, Optional}
 
 import scala.annotation.implicitNotFound
+import scalaz.Id._
 
 /**
  * Typeclass that defines an [[Optional]] from an `S` to an `A` at an index `I`
@@ -17,14 +18,6 @@ abstract class Index[S, I, A] extends Serializable {
   def index(i: I): Optional[S, A]
 }
 
-object Index extends IndexFunctions {
-  /** lift an instance of [[Index]] using an [[Iso]] */
-  def fromIso[S, A, I, B](iso: Iso[S, A])(implicit ev: Index[A, I, B]): Index[S, I, B] = new Index[S, I, B] {
-    override def index(i: I): Optional[S, B] =
-      iso composeOptional ev.index(i)
-  }
-}
-
 trait IndexFunctions {
   def index[S, I, A](i: I)(implicit ev: Index[S, I, A]): Optional[S, A] = ev.index(i)
 
@@ -33,4 +26,85 @@ trait IndexFunctions {
   }
 }
 
+object Index extends IndexFunctions{
+  /** lift an instance of [[Index]] using an [[Iso]] */
+  def fromIso[S, A, I, B](iso: Iso[S, A])(implicit ev: Index[A, I, B]): Index[S, I, B] = new Index[S, I, B] {
+    def index(i: I): Optional[S, B] =
+      iso composeOptional ev.index(i)
+  }
 
+  /************************************************************************************************/
+  /** Std instances                                                                               */
+  /************************************************************************************************/
+  import scalaz.syntax.traverse._
+  import scalaz.std.list._
+  import scalaz.std.stream._
+
+  implicit def listIndex[A]: Index[List[A], Int, A] = new Index[List[A], Int, A] {
+    def index(i: Int) = Optional[List[A], A](
+      l      => if(i < 0) None else l.drop(i).headOption)(
+      a => l => l.zipWithIndex.traverse[Id, A]{
+        case (_    , index) if index == i => a
+        case (value, index)               => value
+      }
+    )
+  }
+
+  implicit def mapIndex[K, V]: Index[Map[K, V], K, V] = atIndex
+
+  implicit def streamIndex[A]: Index[Stream[A], Int, A] = new Index[Stream[A], Int, A] {
+    def index(i: Int) = Optional[Stream[A], A](
+      s      => if(i < 0) None else s.drop(i).headOption)(
+      a => s => s.zipWithIndex.traverse[Id, A]{
+        case (_    , index) if index == i => a
+        case (value, index)               => value
+      }
+    )
+  }
+
+  implicit val stringIndex: Index[String, Int, Char] = new Index[String, Int, Char]{
+    def index(i: Int) = monocle.std.string.stringToList composeOptional Index.index[List[Char], Int, Char](i)
+  }
+
+  implicit def vectorIndex[A]: Index[Vector[A], Int, A] = new Index[Vector[A], Int, A] {
+    def index(i: Int) =
+      Optional[Vector[A], A](v =>
+        if(v.isDefinedAt(i)) Some(v(i))     else None)(a => v =>
+        if(v.isDefinedAt(i)) v.updated(i,a) else v)
+  }
+
+  /************************************************************************************************/
+  /** Scalaz instances                                                                            */
+  /************************************************************************************************/
+
+  import monocle.function.Cons1.{oneAndCons1, nelCons1}
+  import scalaz.{==>>, IList, Order, NonEmptyList, OneAnd}
+
+  implicit def iListIndex[A]: Index[IList[A], Int, A] = new Index[IList[A], Int, A] {
+    def index(i: Int) = Optional[IList[A], A](
+      il      => if(i < 0) None else il.drop(i).headOption)(
+      a => il => il.zipWithIndex.traverse[Id, A]{
+        case (_    , index) if index == i => a
+        case (value, index)               => value
+      }
+    )
+  }
+
+  implicit def iMapIndex[K: Order, V]: Index[K ==>> V, K, V] = atIndex
+
+  implicit def nelIndex[A]: Index[NonEmptyList[A], Int, A] =
+    new Index[NonEmptyList[A], Int, A] {
+      def index(i: Int): Optional[NonEmptyList[A], A] = i match {
+        case 0 => nelCons1.head.asOptional
+        case _ => nelCons1.tail composeOptional iListIndex.index(i-1)
+      }
+    }
+
+  implicit def oneAndIndex[T[_], A](implicit ev: Index[T[A], Int, A]): Index[OneAnd[T, A], Int, A] =
+    new Index[OneAnd[T, A], Int, A]{
+      def index(i: Int) = i match {
+        case 0 => oneAndCons1[T, A].head.asOptional
+        case _ => oneAndCons1[T, A].tail composeOptional ev.index(i - 1)
+      }
+    }
+}

--- a/core/shared/src/main/scala/monocle/function/Index.scala
+++ b/core/shared/src/main/scala/monocle/function/Index.scala
@@ -13,7 +13,7 @@ import scala.annotation.implicitNotFound
  */
 @implicitNotFound("Could not find an instance of Index[${S},${I},${A}], please check Monocle instance location policy to " +
   "find out which import is necessary")
-trait Index[S, I, A] extends Serializable {
+abstract class Index[S, I, A] extends Serializable {
   def index(i: I): Optional[S, A]
 }
 

--- a/core/shared/src/main/scala/monocle/function/Reverse.scala
+++ b/core/shared/src/main/scala/monocle/function/Reverse.scala
@@ -6,7 +6,7 @@ import scala.annotation.implicitNotFound
 
 @implicitNotFound("Could not find an instance of Reverse[${S},${A}], please check Monocle instance location policy to " +
   "find out which import is necessary")
-trait Reverse[S, A] extends Serializable {
+abstract class Reverse[S, A] extends Serializable {
   /** Creates an Iso from S to a reversed S */
   def reverse: Iso[S, A]
 }

--- a/core/shared/src/main/scala/monocle/function/Reverse.scala
+++ b/core/shared/src/main/scala/monocle/function/Reverse.scala
@@ -36,7 +36,7 @@ object Reverse extends ReverseFunctions {
     reverseFromReverseFunction(_.reverse)
 
   implicit def tuple1Reverse[A]: Reverse[Tuple1[A], Tuple1[A]] = new Reverse[Tuple1[A], Tuple1[A]] {
-    val reverse = Iso.id
+    val reverse = Iso.id[Tuple1[A]]
   }
 
   implicit def tuple2Reverse[A, B]: Reverse[(A, B), (B, A)] = new Reverse[(A, B), (B, A)] {

--- a/core/shared/src/main/scala/monocle/function/Reverse.scala
+++ b/core/shared/src/main/scala/monocle/function/Reverse.scala
@@ -11,8 +11,6 @@ abstract class Reverse[S, A] extends Serializable {
   def reverse: Iso[S, A]
 }
 
-object Reverse extends ReverseFunctions
-
 trait ReverseFunctions {
   def reverseFromReverseFunction[S](_reverse: S => S): Reverse[S, S] = new Reverse[S, S] {
     def reverse = Iso(_reverse)(_reverse)
@@ -21,4 +19,62 @@ trait ReverseFunctions {
   def reverse[S, A](implicit ev: Reverse[S, A]): Iso[S, A] = ev.reverse
 
   def _reverse[S](s: S)(implicit ev: Reverse[S, S]): S = ev.reverse.get(s)
+}
+
+object Reverse extends ReverseFunctions {
+  /************************************************************************************************/
+  /** Std instances                                                                               */
+  /************************************************************************************************/
+
+  implicit def listReverse[A]: Reverse[List[A], List[A]] =
+    reverseFromReverseFunction(_.reverse)
+
+  implicit def streamReverse[A]: Reverse[Stream[A], Stream[A]] =
+    reverseFromReverseFunction(_.reverse)
+
+  implicit val stringReverse: Reverse[String, String] =
+    reverseFromReverseFunction(_.reverse)
+
+  implicit def tuple1Reverse[A]: Reverse[Tuple1[A], Tuple1[A]] = new Reverse[Tuple1[A], Tuple1[A]] {
+    def reverse = Iso.id
+  }
+
+  implicit def tuple2Reverse[A, B]: Reverse[(A, B), (B, A)] = new Reverse[(A, B), (B, A)] {
+    def reverse = Iso[(A, B), (B, A)](_.swap)(_.swap)
+  }
+
+  implicit def tuple3Reverse[A, B, C]: Reverse[(A, B, C), (C, B, A)] = new Reverse[(A, B, C), (C, B, A)] {
+    def reverse = Iso{t: (A, B, C) => (t._3, t._2, t._1)}(t => (t._3, t._2, t._1))
+  }
+
+  implicit def tuple4Reverse[A, B, C, D]: Reverse[(A, B, C, D), (D, C, B, A)] = new Reverse[(A, B, C, D), (D, C, B, A)] {
+    def reverse = Iso{t: (A, B, C, D) => (t._4, t._3, t._2, t._1)}(t => (t._4, t._3, t._2, t._1))
+  }
+
+  implicit def tuple5Reverse[A, B, C, D, E]: Reverse[(A, B, C, D, E), (E, D, C, B, A)] = new Reverse[(A, B, C, D, E), (E, D, C, B, A)] {
+    def reverse = Iso{t: (A, B, C, D, E) => (t._5, t._4, t._3, t._2, t._1)}(t => (t._5, t._4, t._3, t._2, t._1))
+  }
+
+  implicit def tuple6Reverse[A, B, C, D, E, F]: Reverse[(A, B, C, D, E, F), (F, E, D, C, B, A)] = new Reverse[(A, B, C, D, E, F), (F, E, D, C, B, A)] {
+    def reverse = Iso{t: (A, B, C, D, E, F) => (t._6, t._5, t._4, t._3, t._2, t._1)}(t => (t._6, t._5, t._4, t._3, t._2, t._1))
+  }
+
+  implicit def vectorReverse[A]: Reverse[Vector[A], Vector[A]] =
+    reverseFromReverseFunction(_.reverse)
+
+  /************************************************************************************************/
+  /** Scalaz instances                                                                            */
+  /************************************************************************************************/
+  import scalaz.{IList, NonEmptyList, Tree}
+
+  implicit def iListReverse[A]: Reverse[IList[A], IList[A]] =
+    reverseFromReverseFunction(_.reverse)
+
+  implicit def nelReverse[A]: Reverse[NonEmptyList[A], NonEmptyList[A]] =
+    reverseFromReverseFunction(_.reverse)
+
+  implicit def treeReverse[A]: Reverse[Tree[A], Tree[A]] = new Reverse[Tree[A], Tree[A]] {
+    def reverse = Iso[Tree[A], Tree[A]](reverseTree)(reverseTree)
+    private def reverseTree(tree: Tree[A]): Tree[A] = Tree.Node(tree.rootLabel, tree.subForest.reverse.map(reverseTree))
+  }
 }

--- a/core/shared/src/main/scala/monocle/function/Reverse.scala
+++ b/core/shared/src/main/scala/monocle/function/Reverse.scala
@@ -13,7 +13,7 @@ abstract class Reverse[S, A] extends Serializable {
 
 trait ReverseFunctions {
   def reverseFromReverseFunction[S](_reverse: S => S): Reverse[S, S] = new Reverse[S, S] {
-    def reverse = Iso(_reverse)(_reverse)
+    val reverse = Iso(_reverse)(_reverse)
   }
 
   def reverse[S, A](implicit ev: Reverse[S, A]): Iso[S, A] = ev.reverse
@@ -36,27 +36,27 @@ object Reverse extends ReverseFunctions {
     reverseFromReverseFunction(_.reverse)
 
   implicit def tuple1Reverse[A]: Reverse[Tuple1[A], Tuple1[A]] = new Reverse[Tuple1[A], Tuple1[A]] {
-    def reverse = Iso.id
+    val reverse = Iso.id
   }
 
   implicit def tuple2Reverse[A, B]: Reverse[(A, B), (B, A)] = new Reverse[(A, B), (B, A)] {
-    def reverse = Iso[(A, B), (B, A)](_.swap)(_.swap)
+    val reverse = Iso[(A, B), (B, A)](_.swap)(_.swap)
   }
 
   implicit def tuple3Reverse[A, B, C]: Reverse[(A, B, C), (C, B, A)] = new Reverse[(A, B, C), (C, B, A)] {
-    def reverse = Iso{t: (A, B, C) => (t._3, t._2, t._1)}(t => (t._3, t._2, t._1))
+    val reverse = Iso{t: (A, B, C) => (t._3, t._2, t._1)}(t => (t._3, t._2, t._1))
   }
 
   implicit def tuple4Reverse[A, B, C, D]: Reverse[(A, B, C, D), (D, C, B, A)] = new Reverse[(A, B, C, D), (D, C, B, A)] {
-    def reverse = Iso{t: (A, B, C, D) => (t._4, t._3, t._2, t._1)}(t => (t._4, t._3, t._2, t._1))
+    val reverse = Iso{t: (A, B, C, D) => (t._4, t._3, t._2, t._1)}(t => (t._4, t._3, t._2, t._1))
   }
 
   implicit def tuple5Reverse[A, B, C, D, E]: Reverse[(A, B, C, D, E), (E, D, C, B, A)] = new Reverse[(A, B, C, D, E), (E, D, C, B, A)] {
-    def reverse = Iso{t: (A, B, C, D, E) => (t._5, t._4, t._3, t._2, t._1)}(t => (t._5, t._4, t._3, t._2, t._1))
+    val reverse = Iso{t: (A, B, C, D, E) => (t._5, t._4, t._3, t._2, t._1)}(t => (t._5, t._4, t._3, t._2, t._1))
   }
 
   implicit def tuple6Reverse[A, B, C, D, E, F]: Reverse[(A, B, C, D, E, F), (F, E, D, C, B, A)] = new Reverse[(A, B, C, D, E, F), (F, E, D, C, B, A)] {
-    def reverse = Iso{t: (A, B, C, D, E, F) => (t._6, t._5, t._4, t._3, t._2, t._1)}(t => (t._6, t._5, t._4, t._3, t._2, t._1))
+    val reverse = Iso{t: (A, B, C, D, E, F) => (t._6, t._5, t._4, t._3, t._2, t._1)}(t => (t._6, t._5, t._4, t._3, t._2, t._1))
   }
 
   implicit def vectorReverse[A]: Reverse[Vector[A], Vector[A]] =
@@ -74,7 +74,7 @@ object Reverse extends ReverseFunctions {
     reverseFromReverseFunction(_.reverse)
 
   implicit def treeReverse[A]: Reverse[Tree[A], Tree[A]] = new Reverse[Tree[A], Tree[A]] {
-    def reverse = Iso[Tree[A], Tree[A]](reverseTree)(reverseTree)
+    val reverse = Iso[Tree[A], Tree[A]](reverseTree)(reverseTree)
     private def reverseTree(tree: Tree[A]): Tree[A] = Tree.Node(tree.rootLabel, tree.subForest.reverse.map(reverseTree))
   }
 }

--- a/core/shared/src/main/scala/monocle/function/Snoc.scala
+++ b/core/shared/src/main/scala/monocle/function/Snoc.scala
@@ -13,7 +13,7 @@ import scala.annotation.implicitNotFound
  */
 @implicitNotFound("Could not find an instance of Snoc[${S},${A}], please check Monocle instance location policy to " +
   "find out which import is necessary")
-trait Snoc[S, A] extends Serializable {
+abstract class Snoc[S, A] extends Serializable {
   def snoc: Prism[S, (S, A)]
 
   def initOption: Optional[S, S] = snoc composeLens first

--- a/core/shared/src/main/scala/monocle/function/Snoc.scala
+++ b/core/shared/src/main/scala/monocle/function/Snoc.scala
@@ -1,10 +1,10 @@
 package monocle.function
 
 import monocle.function.fields._
-import monocle.std.tuple2._
 import monocle.{Iso, Optional, Prism}
 
 import scala.annotation.implicitNotFound
+import scalaz.{Applicative, \/}
 
 /**
  * Typeclass that defines a [[Prism]] between an `S` and its init `S` and last `S`
@@ -20,14 +20,6 @@ abstract class Snoc[S, A] extends Serializable {
   def lastOption: Optional[S, A] = snoc composeLens second
 }
 
-object Snoc extends SnocFunctions {
-  /** lift an instance of [[Snoc]] using an [[Iso]] */
-  def fromIso[S, A, B](iso: Iso[S, A])(implicit ev: Snoc[A, B]): Snoc[S, B] = new Snoc[S, B] {
-    override def snoc: Prism[S, (S, B)] =
-      iso composePrism ev.snoc composeIso iso.reverse.first
-  }
-}
-
 trait SnocFunctions {
   final def snoc[S, A](implicit ev: Snoc[S, A]): Prism[S, (S, A)] = ev.snoc
 
@@ -36,9 +28,66 @@ trait SnocFunctions {
 
   /** append an element to the end */
   final def _snoc[S, A](init: S, last: A)(implicit ev: Snoc[S, A]): S =
-    ev.snoc.reverseGet((init, last))
+  ev.snoc.reverseGet((init, last))
 
   /** deconstruct an S between its init and last */
   final def _unsnoc[S, A](s: S)(implicit ev: Snoc[S, A]): Option[(S, A)] =
-    ev.snoc.getOption(s)
+  ev.snoc.getOption(s)
+}
+
+object Snoc extends SnocFunctions {
+  /** lift an instance of [[Snoc]] using an [[Iso]] */
+  def fromIso[S, A, B](iso: Iso[S, A])(implicit ev: Snoc[A, B]): Snoc[S, B] = new Snoc[S, B] {
+    def snoc: Prism[S, (S, B)] =
+      iso composePrism ev.snoc composeIso iso.reverse.first
+  }
+
+  /************************************************************************************************/
+  /** Std instances                                                                               */
+  /************************************************************************************************/
+  import scalaz.std.option._
+
+  implicit def listSnoc[A]: Snoc[List[A], A] = new Snoc[List[A], A]{
+    def snoc = Prism[List[A], (List[A], A)](
+      s => Applicative[Option].apply2(\/.fromTryCatchNonFatal(s.init).toOption, s.lastOption)((_,_))){
+      case (init, last) => init :+ last
+    }
+  }
+
+  implicit def streamSnoc[A]: Snoc[Stream[A], A] = new Snoc[Stream[A], A]{
+    def snoc = Prism[Stream[A], (Stream[A], A)]( s =>
+      for {
+        init <- if(s.isEmpty) None else Some(s.init)
+        last <- s.lastOption
+      } yield (init, last)){
+      case (init, last) => init :+ last
+    }
+  }
+
+  implicit val stringSnoc: Snoc[String, Char] = new Snoc[String, Char]{
+    def snoc =
+      Prism[String, (String, Char)](
+        s => if(s.isEmpty) None else Some((s.init, s.last))){
+        case (init, last) => init :+ last
+      }
+  }
+
+  implicit def vectorSnoc[A]: Snoc[Vector[A], A] = new Snoc[Vector[A], A]{
+    def snoc = Prism[Vector[A], (Vector[A], A)](
+      v => if(v.isEmpty) None else Some((v.init, v.last))){
+      case (xs, x) => xs :+ x
+    }
+  }
+
+  /************************************************************************************************/
+  /** Scalaz instances                                                                            */
+  /************************************************************************************************/
+  import scalaz.IList
+
+  implicit def iListSnoc[A]: Snoc[IList[A], A] = new Snoc[IList[A], A]{
+    def snoc = Prism[IList[A], (IList[A], A)](
+      il => Applicative[Option].apply2(il.initOption, il.lastOption)((_,_))){
+      case (init, last) => init :+ last
+    }
+  }
 }

--- a/core/shared/src/main/scala/monocle/function/Snoc.scala
+++ b/core/shared/src/main/scala/monocle/function/Snoc.scala
@@ -28,17 +28,17 @@ trait SnocFunctions {
 
   /** append an element to the end */
   final def _snoc[S, A](init: S, last: A)(implicit ev: Snoc[S, A]): S =
-  ev.snoc.reverseGet((init, last))
+    ev.snoc.reverseGet((init, last))
 
   /** deconstruct an S between its init and last */
   final def _unsnoc[S, A](s: S)(implicit ev: Snoc[S, A]): Option[(S, A)] =
-  ev.snoc.getOption(s)
+    ev.snoc.getOption(s)
 }
 
 object Snoc extends SnocFunctions {
   /** lift an instance of [[Snoc]] using an [[Iso]] */
   def fromIso[S, A, B](iso: Iso[S, A])(implicit ev: Snoc[A, B]): Snoc[S, B] = new Snoc[S, B] {
-    def snoc: Prism[S, (S, B)] =
+    val snoc: Prism[S, (S, B)] =
       iso composePrism ev.snoc composeIso iso.reverse.first
   }
 
@@ -48,14 +48,14 @@ object Snoc extends SnocFunctions {
   import scalaz.std.option._
 
   implicit def listSnoc[A]: Snoc[List[A], A] = new Snoc[List[A], A]{
-    def snoc = Prism[List[A], (List[A], A)](
+    val snoc = Prism[List[A], (List[A], A)](
       s => Applicative[Option].apply2(\/.fromTryCatchNonFatal(s.init).toOption, s.lastOption)((_,_))){
       case (init, last) => init :+ last
     }
   }
 
   implicit def streamSnoc[A]: Snoc[Stream[A], A] = new Snoc[Stream[A], A]{
-    def snoc = Prism[Stream[A], (Stream[A], A)]( s =>
+    val snoc = Prism[Stream[A], (Stream[A], A)]( s =>
       for {
         init <- if(s.isEmpty) None else Some(s.init)
         last <- s.lastOption
@@ -65,7 +65,7 @@ object Snoc extends SnocFunctions {
   }
 
   implicit val stringSnoc: Snoc[String, Char] = new Snoc[String, Char]{
-    def snoc =
+    val snoc =
       Prism[String, (String, Char)](
         s => if(s.isEmpty) None else Some((s.init, s.last))){
         case (init, last) => init :+ last
@@ -73,7 +73,7 @@ object Snoc extends SnocFunctions {
   }
 
   implicit def vectorSnoc[A]: Snoc[Vector[A], A] = new Snoc[Vector[A], A]{
-    def snoc = Prism[Vector[A], (Vector[A], A)](
+    val snoc = Prism[Vector[A], (Vector[A], A)](
       v => if(v.isEmpty) None else Some((v.init, v.last))){
       case (xs, x) => xs :+ x
     }
@@ -85,7 +85,7 @@ object Snoc extends SnocFunctions {
   import scalaz.IList
 
   implicit def iListSnoc[A]: Snoc[IList[A], A] = new Snoc[IList[A], A]{
-    def snoc = Prism[IList[A], (IList[A], A)](
+    val snoc = Prism[IList[A], (IList[A], A)](
       il => Applicative[Option].apply2(il.initOption, il.lastOption)((_,_))){
       case (init, last) => init :+ last
     }

--- a/core/shared/src/main/scala/monocle/function/Snoc1.scala
+++ b/core/shared/src/main/scala/monocle/function/Snoc1.scala
@@ -30,17 +30,17 @@ trait Snoc1Functions {
 
   /** append an element to the end */
   final def _snoc1[S, I, L](init: I, last: L)(implicit ev: Snoc1[S, I, L]): S =
-  ev.snoc1.reverseGet((init, last))
+    ev.snoc1.reverseGet((init, last))
 
   /** deconstruct an S between its init and last */
   final def _unsnoc1[S, I, L](s: S)(implicit ev: Snoc1[S, I, L]): (I, L) =
-  ev.snoc1.get(s)
+    ev.snoc1.get(s)
 }
 
 object Snoc1 extends Snoc1Functions {
   /** lift an instance of [[Snoc1]] using an [[Iso]] */
   def fromIso[S, A, I, L](iso: Iso[S, A])(implicit ev: Snoc1[A, I, L]): Snoc1[S, I, L] = new Snoc1[S, I, L] {
-    def snoc1: Iso[S, (I, L)] =
+    val snoc1: Iso[S, (I, L)] =
       iso composeIso ev.snoc1
   }
 
@@ -49,19 +49,19 @@ object Snoc1 extends Snoc1Functions {
   /************************************************************************************************/
 
   implicit def tuple2Snoc1[A1, A2]: Snoc1[(A1, A2), A1, A2] = new Snoc1[(A1, A2), A1, A2] {
-    def snoc1 = Iso[(A1, A2), (A1, A2)](identity)(identity)
+    val snoc1 = Iso[(A1, A2), (A1, A2)](identity)(identity)
   }
 
   implicit def tuple3Snoc1[A1, A2, A3]: Snoc1[(A1, A2, A3), (A1, A2), A3] = new Snoc1[(A1, A2, A3), (A1, A2), A3]{
-    def snoc1 = Iso[(A1, A2, A3), ((A1, A2), A3)](t => ((t._1, t._2), t._3)){ case (i, l) => (i._1, i._2, l) }
+    val snoc1 = Iso[(A1, A2, A3), ((A1, A2), A3)](t => ((t._1, t._2), t._3)){ case (i, l) => (i._1, i._2, l) }
   }
 
   implicit def tuple4Snoc1[A1, A2, A3, A4]: Snoc1[(A1, A2, A3, A4), (A1, A2, A3), A4] = new Snoc1[(A1, A2, A3, A4), (A1, A2, A3), A4]{
-    def snoc1 = Iso[(A1, A2, A3, A4), ((A1, A2, A3), A4)](t => ((t._1, t._2, t._3), t._4)){ case (i, l) => (i._1, i._2, i._3, l) }
+    val snoc1 = Iso[(A1, A2, A3, A4), ((A1, A2, A3), A4)](t => ((t._1, t._2, t._3), t._4)){ case (i, l) => (i._1, i._2, i._3, l) }
   }
 
   implicit def tuple6Snoc1[A1, A2, A3, A4, A5, A6]: Snoc1[(A1, A2, A3, A4, A5, A6), (A1, A2, A3, A4, A5), A6] = new Snoc1[(A1, A2, A3, A4, A5, A6), (A1, A2, A3, A4, A5), A6]{
-    def snoc1 = Iso[(A1, A2, A3, A4, A5, A6), ((A1, A2, A3, A4, A5), A6)](t => ((t._1, t._2, t._3, t._4, t._5), t._6)){ case (i, l) => (i._1, i._2, i._3, i._4, i._5, l) }
+    val snoc1 = Iso[(A1, A2, A3, A4, A5, A6), ((A1, A2, A3, A4, A5), A6)](t => ((t._1, t._2, t._3, t._4, t._5), t._6)){ case (i, l) => (i._1, i._2, i._3, i._4, i._5, l) }
   }
 
   /************************************************************************************************/
@@ -69,9 +69,8 @@ object Snoc1 extends Snoc1Functions {
   /************************************************************************************************/
   import scalaz.{IList, NonEmptyList}
 
-  implicit def nelSnoc1[A]:Snoc1[NonEmptyList[A], IList[A], A] =
-    new Snoc1[NonEmptyList[A], IList[A], A]{
-      def snoc1: Iso[NonEmptyList[A], (IList[A], A)] =
-        Iso((nel:NonEmptyList[A]) => nel.init -> nel.last){case (i,l) => NonEmptyList.nel(l, i.reverse).reverse}
-    }
+  implicit def nelSnoc1[A]:Snoc1[NonEmptyList[A], IList[A], A] = new Snoc1[NonEmptyList[A], IList[A], A]{
+    val snoc1: Iso[NonEmptyList[A], (IList[A], A)] =
+      Iso((nel:NonEmptyList[A]) => nel.init -> nel.last){case (i,l) => NonEmptyList.nel(l, i.reverse).reverse}
+  }
 }

--- a/core/shared/src/main/scala/monocle/function/Snoc1.scala
+++ b/core/shared/src/main/scala/monocle/function/Snoc1.scala
@@ -22,14 +22,6 @@ abstract class Snoc1[S, I, L] extends Serializable {
   def last: Lens[S, L] = snoc1 composeLens second
 }
 
-object Snoc1 extends Snoc1Functions {
-  /** lift an instance of [[Snoc1]] using an [[Iso]] */
-  def fromIso[S, A, I, L](iso: Iso[S, A])(implicit ev: Snoc1[A, I, L]): Snoc1[S, I, L] = new Snoc1[S, I, L] {
-    override def snoc1: Iso[S, (I, L)] =
-      iso composeIso ev.snoc1
-  }
-}
-
 trait Snoc1Functions {
   final def snoc1[S, I, L](implicit ev: Snoc1[S, I, L]): Iso[S, (I, L)] = ev.snoc1
 
@@ -38,9 +30,48 @@ trait Snoc1Functions {
 
   /** append an element to the end */
   final def _snoc1[S, I, L](init: I, last: L)(implicit ev: Snoc1[S, I, L]): S =
-    ev.snoc1.reverseGet((init, last))
+  ev.snoc1.reverseGet((init, last))
 
   /** deconstruct an S between its init and last */
   final def _unsnoc1[S, I, L](s: S)(implicit ev: Snoc1[S, I, L]): (I, L) =
-    ev.snoc1.get(s)
+  ev.snoc1.get(s)
+}
+
+object Snoc1 extends Snoc1Functions {
+  /** lift an instance of [[Snoc1]] using an [[Iso]] */
+  def fromIso[S, A, I, L](iso: Iso[S, A])(implicit ev: Snoc1[A, I, L]): Snoc1[S, I, L] = new Snoc1[S, I, L] {
+    def snoc1: Iso[S, (I, L)] =
+      iso composeIso ev.snoc1
+  }
+
+  /************************************************************************************************/
+  /** Std instances                                                                               */
+  /************************************************************************************************/
+
+  implicit def tuple2Snoc1[A1, A2]: Snoc1[(A1, A2), A1, A2] = new Snoc1[(A1, A2), A1, A2] {
+    def snoc1 = Iso[(A1, A2), (A1, A2)](identity)(identity)
+  }
+
+  implicit def tuple3Snoc1[A1, A2, A3]: Snoc1[(A1, A2, A3), (A1, A2), A3] = new Snoc1[(A1, A2, A3), (A1, A2), A3]{
+    def snoc1 = Iso[(A1, A2, A3), ((A1, A2), A3)](t => ((t._1, t._2), t._3)){ case (i, l) => (i._1, i._2, l) }
+  }
+
+  implicit def tuple4Snoc1[A1, A2, A3, A4]: Snoc1[(A1, A2, A3, A4), (A1, A2, A3), A4] = new Snoc1[(A1, A2, A3, A4), (A1, A2, A3), A4]{
+    def snoc1 = Iso[(A1, A2, A3, A4), ((A1, A2, A3), A4)](t => ((t._1, t._2, t._3), t._4)){ case (i, l) => (i._1, i._2, i._3, l) }
+  }
+
+  implicit def tuple6Snoc1[A1, A2, A3, A4, A5, A6]: Snoc1[(A1, A2, A3, A4, A5, A6), (A1, A2, A3, A4, A5), A6] = new Snoc1[(A1, A2, A3, A4, A5, A6), (A1, A2, A3, A4, A5), A6]{
+    def snoc1 = Iso[(A1, A2, A3, A4, A5, A6), ((A1, A2, A3, A4, A5), A6)](t => ((t._1, t._2, t._3, t._4, t._5), t._6)){ case (i, l) => (i._1, i._2, i._3, i._4, i._5, l) }
+  }
+
+  /************************************************************************************************/
+  /** Scalaz instances                                                                            */
+  /************************************************************************************************/
+  import scalaz.{IList, NonEmptyList}
+
+  implicit def nelSnoc1[A]:Snoc1[NonEmptyList[A], IList[A], A] =
+    new Snoc1[NonEmptyList[A], IList[A], A]{
+      def snoc1: Iso[NonEmptyList[A], (IList[A], A)] =
+        Iso((nel:NonEmptyList[A]) => nel.init -> nel.last){case (i,l) => NonEmptyList.nel(l, i.reverse).reverse}
+    }
 }

--- a/core/shared/src/main/scala/monocle/function/Snoc1.scala
+++ b/core/shared/src/main/scala/monocle/function/Snoc1.scala
@@ -15,7 +15,7 @@ import scala.annotation.implicitNotFound
  */
 @implicitNotFound("Could not find an instance of Snoc1[${S}, ${I}, ${L}], please check Monocle instance location policy to " +
   "find out which import is necessary")
-trait Snoc1[S, I, L] extends Serializable {
+abstract class Snoc1[S, I, L] extends Serializable {
   def snoc1: Iso[S, (I, L)]
 
   def init: Lens[S, I] = snoc1 composeLens first

--- a/core/shared/src/main/scala/monocle/function/Wrapped.scala
+++ b/core/shared/src/main/scala/monocle/function/Wrapped.scala
@@ -15,10 +15,18 @@ abstract class Wrapped[S, A] extends Serializable {
   def wrapped: Iso[S, A]
 }
 
-object Wrapped extends WrappedFunctions
-
 trait WrappedFunctions {
   def wrapped[S, A](implicit ev: Wrapped[S, A]): Iso[S, A] = ev.wrapped
 
   def unwrapped[S, A](implicit ev: Wrapped[S, A]): Iso[A, S] = ev.wrapped.reverse
+}
+
+object Wrapped extends WrappedFunctions {
+  import scalaz.{@@, Tag}
+
+  implicit def tagWrapped[A, B]: Wrapped[A @@ B, A] =
+    new Wrapped[A @@ B, A] {
+      val wrapped: Iso[A @@ B, A] =
+        Iso(Tag.unwrap[A, B])(Tag.apply)
+    }
 }

--- a/core/shared/src/main/scala/monocle/function/Wrapped.scala
+++ b/core/shared/src/main/scala/monocle/function/Wrapped.scala
@@ -2,8 +2,6 @@ package monocle.function
 
 import monocle.Iso
 
-import scalaz.Functor
-
 import scala.annotation.implicitNotFound
 
 /**
@@ -13,9 +11,11 @@ import scala.annotation.implicitNotFound
   */
 @implicitNotFound("Could not find an instance of Wrapped[${S},${A}], please check Monocle instance location policy to " +
   "find out which import is necessary")
-trait Wrapped[S, A] extends Serializable {
+abstract class Wrapped[S, A] extends Serializable {
   def wrapped: Iso[S, A]
 }
+
+object Wrapped extends WrappedFunctions
 
 trait WrappedFunctions {
   def wrapped[S, A](implicit ev: Wrapped[S, A]): Iso[S, A] = ev.wrapped

--- a/core/shared/src/main/scala/monocle/function/Wrapped.scala
+++ b/core/shared/src/main/scala/monocle/function/Wrapped.scala
@@ -17,16 +17,14 @@ abstract class Wrapped[S, A] extends Serializable {
 
 trait WrappedFunctions {
   def wrapped[S, A](implicit ev: Wrapped[S, A]): Iso[S, A] = ev.wrapped
-
   def unwrapped[S, A](implicit ev: Wrapped[S, A]): Iso[A, S] = ev.wrapped.reverse
 }
 
 object Wrapped extends WrappedFunctions {
   import scalaz.{@@, Tag}
 
-  implicit def tagWrapped[A, B]: Wrapped[A @@ B, A] =
-    new Wrapped[A @@ B, A] {
-      val wrapped: Iso[A @@ B, A] =
-        Iso(Tag.unwrap[A, B])(Tag.apply)
-    }
+  implicit def tagWrapped[A, B]: Wrapped[A @@ B, A] = new Wrapped[A @@ B, A] {
+    val wrapped: Iso[A @@ B, A] =
+      Iso(Tag.unwrap[A, B])(Tag.apply)
+  }
 }

--- a/core/shared/src/main/scala/monocle/std/All.scala
+++ b/core/shared/src/main/scala/monocle/std/All.scala
@@ -16,16 +16,8 @@ trait StdInstances
   with    MapOptics
   with    MaybeOptics
   with    OptionOptics
-  with    SetOptics
-  with    StreamOptics
   with    StringOptics
   with    Tuple1Optics
-  with    Tuple2Optics
-  with    Tuple3Optics
-  with    Tuple4Optics
-  with    Tuple5Optics
-  with    Tuple6Optics
-  with    VectorOptics
   // Scalaz Instances
   with    CofreeOptics
   with    Either3Optics
@@ -33,9 +25,6 @@ trait StdInstances
   with    TheseOptics
   with    IListInstances
   with    IMapOptics
-  with    ISetOptics
   with    NonEmptyListOptics
-  with    OneAndOptics
-  with    TagOptics
   with    TreeOptics
   with    ValidationOptics

--- a/core/shared/src/main/scala/monocle/std/Char.scala
+++ b/core/shared/src/main/scala/monocle/std/Char.scala
@@ -3,14 +3,11 @@ package monocle.std
 import monocle.Prism
 import monocle.internal.Bounded
 
-import scalaz.Order
+import scalaz.std.anyVal.{char => charInstances}
 
 object char extends CharOptics
 
 trait CharOptics {
-
-  implicit val charOrder: Order[Char] =
-    Order.fromScalaOrdering[Char]
 
   val charToBoolean: Prism[Char, Boolean] =
     Bounded.orderingBoundedSafeCast[Char, Boolean]{

--- a/core/shared/src/main/scala/monocle/std/Cofree.scala
+++ b/core/shared/src/main/scala/monocle/std/Cofree.scala
@@ -1,23 +1,13 @@
 package monocle.std
 
-import monocle.function._
-import monocle.{Lens, PIso, Iso, Optional, PTraversal, Traversal}
+import monocle.{Iso, PIso}
 
-import scalaz.Cofree._
 import scalaz.Tree.Node
-import scalaz.{Cofree, Free, Applicative, Traverse, OneAnd, Tree}
+import scalaz.{Cofree, OneAnd, Tree}
 
 object cofree extends CofreeOptics
 
 trait CofreeOptics {
-
-  private def toStream[A](optC: Option[Cofree[Option, A]]): Stream[A] =
-    optC.fold(Stream.empty[A])(c => c.head #:: toStream(c.tail))
-
-  private def fromStream[A, B](z: A, c: Stream[A]): Cofree[Option, A] = c match {
-    case head #:: tail => Cofree.delay(z, Some(fromStream(head, tail)))
-    case _ => Cofree(z, None: Option[Cofree[Option, A]])
-  }
 
   /** Polymorphic isomorphism between `Cofree[Option, _]` and `OneAnd[Stream, _]` */
   def pCofreeToStream[A, B]: PIso[Cofree[Option, A], Cofree[Option, B],
@@ -46,30 +36,11 @@ trait CofreeOptics {
   def cofreeToTree[A]: Iso[Cofree[Stream, A], Tree[A]] =
     pCofreeToTree[A, A]
 
+  private def toStream[A](optC: Option[Cofree[Option, A]]): Stream[A] =
+    optC.fold(Stream.empty[A])(c => c.head #:: toStream(c.tail))
 
-  /** Evidence that cofree structures can be split up into a `head` and a `tail` */
-  implicit def cofreeCons1[S[_], A]: Cons1[Cofree[S, A], A, S[Cofree[S, A]]] =
-    new Cons1[Cofree[S, A], A, S[Cofree[S, A]]] {
-
-      def cons1: Iso[Cofree[S, A], (A, S[Cofree[S, A]])]  =
-        Iso((c: Cofree[S, A]) => (c.head, c.tail)){ case (h, t) => Cofree(h, t) }
-
-      /** Overridden to prevent forcing evaluation of the `tail` when we're only
-        * interested in using the `head` */
-      override def head: Lens[Cofree[S, A], A] =
-        Lens((c: Cofree[S, A]) => c.head)(h => c => Cofree.delay(h, c.tail))
-    }
-
-
-  /** Trivial `Each` instance due to `Cofree S` being traversable when `S` is */
-  implicit def cofreeEach[S[_]: Traverse, A]: Each[Cofree[S, A], A] =
-    Each.traverseEach[({type L[X] = Cofree[S, X]})#L, A]
-
-  implicit def cofreePlated[S[_]: Traverse, A]: Plated[Cofree[S, A]] = new Plated[Cofree[S, A]] {
-    val plate: Traversal[Cofree[S, A], Cofree[S, A]] = new Traversal[Cofree[S, A], Cofree[S, A]] {
-      def modifyF[F[_]: Applicative](f: Cofree[S, A] => F[Cofree[S, A]])(s: Cofree[S, A]): F[Cofree[S, A]] =
-        Applicative[F].map(Traverse[S].traverse(s.t.run)(f))(Cofree(s.head, _))
-    }
+  private def fromStream[A, B](z: A, c: Stream[A]): Cofree[Option, A] = c match {
+    case head #:: tail => Cofree.delay(z, Some(fromStream(head, tail)))
+    case _ => Cofree(z, None: Option[Cofree[Option, A]])
   }
-
 }

--- a/core/shared/src/main/scala/monocle/std/Free.scala
+++ b/core/shared/src/main/scala/monocle/std/Free.scala
@@ -1,22 +1,7 @@
 package monocle.std
 
-import monocle.function._
-import monocle.Traversal
+@deprecated("instances have been move to typeclass companion object", since = "1.4.0")
+object free
 
-import scalaz.{Applicative, Free, Traverse}
-
-object free extends FreeOptics
-
-trait FreeOptics {
-
-  implicit def freePlated[S[_]: Traverse, A]: Plated[Free[S, A]] = new Plated[Free[S, A]] {
-    val plate: Traversal[Free[S, A], Free[S, A]] = new Traversal[Free[S, A], Free[S, A]] {
-      def modifyF[F[_]: Applicative](f: Free[S, A] => F[Free[S, A]])(s: Free[S, A]): F[Free[S, A]] =
-        s.resume.fold(
-          as => Applicative[F].map(Traverse[S].traverse(as)(f))(Free.roll),
-          x => Applicative[F].point(Free.point(x))
-        )
-    }
-  }
-
-}
+@deprecated("instances have been move to typeclass companion object", since = "1.4.0")
+trait FreeOptics

--- a/core/shared/src/main/scala/monocle/std/Function.scala
+++ b/core/shared/src/main/scala/monocle/std/Function.scala
@@ -1,37 +1,13 @@
 package monocle.std
 
 import monocle.Iso
-import monocle.function.Curry
 
 object function extends FunctionOptics
 
-trait FunctionOptics  extends FunctionOptics1  {
-
+trait FunctionOptics {
   final def flip[A, B, C]: Iso[A => B => C, B => A => C] =
     Iso(flipped[A, B, C])(flipped)
 
   final def flipped[A, B, C]: (A => B => C) => (B => A => C) =
     f => a => b => f(b)(a)
-
-  implicit def curry5[A, B, C, D, E, F] = new Curry[(A, B, C, D, E) => F, A => B => C => D => E => F] {
-    def curry = Iso((_: (A, B, C, D, E) => F).curried)(f => Function.uncurried(f))
-  }
-}
-
-trait FunctionOptics1 extends FunctionOptics2 {
-  implicit def curry4[A, B, C, D, E] = new Curry[(A, B, C, D) => E, A => B => C => D => E] {
-    def curry = Iso((_: (A, B, C, D) => E).curried)(f => Function.uncurried(f))
-  }
-}
-
-trait FunctionOptics2 extends FunctionOptics3 {
-  implicit def curry3[A, B, C, D] = new Curry[(A, B, C) => D, A => B => C => D] {
-    def curry = Iso((_: (A, B, C) => D).curried)(f => Function.uncurried(f))
-  }
-}
-
-trait FunctionOptics3 {
-  implicit def curry2[A, B, C] = new Curry[(A, B) => C, A => B => C] {
-    def curry = Iso((_: (A, B) => C).curried)(f => Function.uncurried(f))
-  }
 }

--- a/core/shared/src/main/scala/monocle/std/IList.scala
+++ b/core/shared/src/main/scala/monocle/std/IList.scala
@@ -1,71 +1,15 @@
 package monocle.std
 
-import monocle.function._
-import monocle.{Iso, Optional, PIso, Prism, Traversal}
+import monocle.{Iso, PIso}
 
-import scalaz.Id.Id
-import scalaz.std.option._
-import scalaz.syntax.traverse._
-import scalaz.{Applicative, ICons, IList, INil}
+import scalaz.IList
 
 object ilist extends IListInstances
 
 trait IListInstances {
-
   final def pIListToList[A, B]: PIso[IList[A], IList[B], List[A], List[B]] =
     PIso[IList[A], IList[B], List[A], List[B]](_.toList)(IList.fromList)
 
   final def iListToList[A]: Iso[IList[A], List[A]] =
     pIListToList[A, A]
-
-  implicit def iListEmpty[A]: Empty[IList[A]] = new Empty[IList[A]] {
-    def empty = Prism[IList[A], Unit](l => if(l.isEmpty) Some(()) else None)(_ => IList.empty)
-  }
-
-  implicit def iNilEmpty[A]: Empty[INil[A]] = new Empty[INil[A]] {
-    def empty = Prism[INil[A], Unit](_ => Some(()))(_ => INil())
-  }
-
-  implicit def iListEach[A]: Each[IList[A], A] = Each.traverseEach[IList, A]
-
-  implicit def iListIndex[A]: Index[IList[A], Int, A] = new Index[IList[A], Int, A] {
-    def index(i: Int) = Optional[IList[A], A](
-      il      => if(i < 0) None else il.drop(i).headOption)(
-      a => il => il.zipWithIndex.traverse[Id, A]{
-        case (_    , index) if index == i => a
-        case (value, index)               => value
-      }
-    )
-  }
-
-  implicit def iListFilterIndex[A]: FilterIndex[IList[A], Int, A] =
-    FilterIndex.traverseFilterIndex[IList, A](_.zipWithIndex)
-
-  implicit def iListCons[A]: Cons[IList[A], A] = new Cons[IList[A], A]{
-    def cons = Prism[IList[A], (A, IList[A])]{
-      case INil()       => None
-      case ICons(x, xs) => Some((x, xs))
-    }{ case (a, s) => ICons(a, s) }
-  }
-
-  implicit def iListSnoc[A]: Snoc[IList[A], A] = new Snoc[IList[A], A]{
-    def snoc = Prism[IList[A], (IList[A], A)](
-      il => Applicative[Option].apply2(il.initOption, il.lastOption)((_,_))){
-      case (init, last) => init :+ last
-    }
-  }
-
-  implicit def iListReverse[A]: Reverse[IList[A], IList[A]] =
-    Reverse.reverseFromReverseFunction[IList[A]](_.reverse)
-
-  implicit def ilistPlated[A]: Plated[IList[A]] = new Plated[IList[A]] {
-    val plate: Traversal[IList[A], IList[A]] = new Traversal[IList[A], IList[A]] {
-      def modifyF[F[_]: Applicative](f: IList[A] => F[IList[A]])(s: IList[A]): F[IList[A]] =
-        s match {
-          case ICons(x, xs) => Applicative[F].map(f(xs))(x :: _)
-          case INil() => Applicative[F].point(INil())
-        }
-    }
-  }
-
 }

--- a/core/shared/src/main/scala/monocle/std/IMap.scala
+++ b/core/shared/src/main/scala/monocle/std/IMap.scala
@@ -1,36 +1,5 @@
 package monocle.std
 
-import monocle.function._
-import monocle.{Lens, Prism, Traversal}
-
-import scalaz.std.list._
-import scalaz.syntax.traverse._
-import scalaz.{==>>, Applicative, Order}
-
 object imap extends IMapOptics
 
-trait IMapOptics {
-
-  implicit def iMapEmpty[K, V]: Empty[K ==>> V] = new Empty[K ==>> V] {
-    def empty = Prism[K ==>> V, Unit](m => if(m.isEmpty) Some(()) else None)(_ => ==>>.empty)
-  }
-
-  implicit def atIMap[K: Order, V]: At[K ==>> V, K, Option[V]] = new At[K ==>> V, K, Option[V]]{
-    def at(i: K) = Lens{m: ==>>[K, V] => m.lookup(i)}(optV => map => optV.fold(map - i)(v => map + (i -> v)))
-  }
-
-  implicit def iMapEach[K, V]: Each[K ==>> V, V] = Each.traverseEach[K ==>> ?, V]
-
-  implicit def iMapIndex[K: Order, V]: Index[K ==>> V, K, V] = Index.atIndex
-
-  implicit def iMapFilterIndex[K: Order, V]: FilterIndex[K ==>> V, K, V] = new FilterIndex[K ==>> V, K, V] {
-    import scalaz.syntax.applicative._
-    def filterIndex(predicate: K => Boolean) = new Traversal[K ==>> V, V] {
-      def modifyF[F[_]: Applicative](f: V => F[V])(s: K ==>> V): F[K ==>> V] =
-        s.toList.traverse{ case (k, v) =>
-          (if(predicate(k)) f(v) else v.point[F]).strengthL(k)
-        }.map(==>>.fromList(_))
-    }
-  }
-
-}
+trait IMapOptics

--- a/core/shared/src/main/scala/monocle/std/ISet.scala
+++ b/core/shared/src/main/scala/monocle/std/ISet.scala
@@ -1,20 +1,7 @@
 package monocle.std
 
-import monocle.function.{At, Empty}
-import monocle.{Lens, Prism}
+@deprecated("instances have been move to typeclass companion object", since = "1.4.0")
+object iset
 
-import scalaz.{ISet, Order}
-
-object iset extends ISetOptics
-
-trait ISetOptics {
-
-  implicit def emptyISet[A]: Empty[ISet[A]] = new Empty[ISet[A]] {
-    def empty = Prism[ISet[A], Unit](s => if(s.isEmpty) Some(()) else None)(_ => ISet.empty[A])
-  }
-
-  implicit def atISet[A: Order]: At[ISet[A], A, Boolean] = new At[ISet[A], A, Boolean] {
-    def at(a: A) = Lens[ISet[A], Boolean](_.member(a))(b => set => if(b) set insert a else set delete a)
-  }
-
-}
+@deprecated("instances have been move to typeclass companion object", since = "1.4.0")
+trait ISetOptics

--- a/core/shared/src/main/scala/monocle/std/List.scala
+++ b/core/shared/src/main/scala/monocle/std/List.scala
@@ -1,72 +1,13 @@
 package monocle.std
 
-import monocle.function._
-import monocle.{Iso, PIso, Optional, Prism, Traversal}
-
-import scalaz.Id.Id
-import scalaz.std.list._
-import scalaz.std.option._
-import scalaz.syntax.traverse._
-import scalaz.{Applicative, \/}
+import monocle.{Iso, PIso}
 
 object list extends ListOptics
 
 trait ListOptics {
-
   def pListToVector[A, B]: PIso[List[A], List[B], Vector[A], Vector[B]] =
     PIso[List[A], List[B], Vector[A], Vector[B]](_.toVector)(_.toList)
 
   def listToVector[A]: Iso[List[A], Vector[A]] =
     pListToVector[A, A]
-
-  implicit def listEmpty[A]: Empty[List[A]] = new Empty[List[A]] {
-    def empty = Prism[List[A], Unit](l => if(l.isEmpty) Some(()) else None)(_ => List.empty)
-  }
-
-  implicit val nilEmpty: Empty[Nil.type] = new Empty[Nil.type] {
-    def empty = Prism[Nil.type, Unit](_ => Some(()))(_ => Nil)
-  }
-
-  implicit def listReverse[A]: Reverse[List[A], List[A]] =
-    Reverse.reverseFromReverseFunction[List[A]](_.reverse)
-
-  implicit def listEach[A]: Each[List[A], A] = Each.traverseEach[List, A]
-
-  implicit def listIndex[A]: Index[List[A], Int, A] = new Index[List[A], Int, A] {
-    def index(i: Int) = Optional[List[A], A](
-      l      => if(i < 0) None else l.drop(i).headOption)(
-      a => l => l.zipWithIndex.traverse[Id, A]{
-        case (_    , index) if index == i => a
-        case (value, index)               => value
-      }
-    )
-  }
-
-  implicit def listFilterIndex[A]: FilterIndex[List[A], Int, A] =
-    FilterIndex.traverseFilterIndex[List, A](_.zipWithIndex)
-
-  implicit def listCons[A]: Cons[List[A], A] = new Cons[List[A], A]{
-    def cons = Prism[List[A], (A, List[A])]{
-      case Nil     => None
-      case x :: xs => Some((x, xs))
-    }{ case (a, s) => a :: s }
-  }
-
-  implicit def listSnoc[A]: Snoc[List[A], A] = new Snoc[List[A], A]{
-    def snoc = Prism[List[A], (List[A], A)](
-      s => Applicative[Option].apply2(\/.fromTryCatchNonFatal(s.init).toOption, s.lastOption)((_,_))){
-      case (init, last) => init :+ last
-    }
-  }
-
-  implicit def listPlated[A]: Plated[List[A]] = new Plated[List[A]] {
-    val plate: Traversal[List[A], List[A]] = new Traversal[List[A], List[A]] {
-      def modifyF[F[_]: Applicative](f: List[A] => F[List[A]])(s: List[A]): F[List[A]] =
-        s match {
-          case x :: xs => Applicative[F].map(f(xs))(x :: _)
-          case Nil => Applicative[F].point(Nil)
-        }
-    }
-  }
-
 }

--- a/core/shared/src/main/scala/monocle/std/Map.scala
+++ b/core/shared/src/main/scala/monocle/std/Map.scala
@@ -1,40 +1,10 @@
 package monocle.std
 
-import monocle.function._
-import monocle.{Iso, Lens, Prism, Traversal}
-
-import scalaz.std.list._
-import scalaz.std.map._
-import scalaz.syntax.traverse._
-import scalaz.Applicative
+import monocle.Iso
 
 object map extends MapOptics
 
 trait MapOptics {
-
   def mapToSet[K]: Iso[Map[K, Unit], Set[K]] =
     Iso[Map[K, Unit], Set[K]](_.keySet)(_.map(k => (k, ())).toMap)
-
-  implicit def mapEmpty[K, V]: Empty[Map[K, V]] = new Empty[Map[K, V]] {
-    def empty = Prism[Map[K, V], Unit](m => if(m.isEmpty) Some(()) else None)(_ => Map.empty)
-  }
-
-  implicit def atMap[K, V]: At[Map[K, V], K, Option[V]] = new At[Map[K, V], K, Option[V]]{
-    def at(i: K) = Lens{m: Map[K, V] => m.get(i)}(optV => map => optV.fold(map - i)(v => map + (i -> v)))
-  }
-
-  implicit def mapEach[K, V]: Each[Map[K, V], V] = Each.traverseEach[Map[K, ?], V]
-
-  implicit def mapIndex[K, V]: Index[Map[K, V], K, V] = Index.atIndex
-
-  implicit def mapFilterIndex[K, V]: FilterIndex[Map[K,V], K, V] = new FilterIndex[Map[K, V], K, V] {
-    import scalaz.syntax.applicative._
-    def filterIndex(predicate: K => Boolean) = new Traversal[Map[K, V], V] {
-      def modifyF[F[_]: Applicative](f: V => F[V])(s: Map[K, V]): F[Map[K, V]] =
-        s.toList.traverse{ case (k, v) =>
-          (if(predicate(k)) f(v) else v.point[F]).strengthL(k)
-        }.map(_.toMap)
-    }
-  }
-
 }

--- a/core/shared/src/main/scala/monocle/std/Maybe.scala
+++ b/core/shared/src/main/scala/monocle/std/Maybe.scala
@@ -1,6 +1,5 @@
 package monocle.std
 
-import monocle.function.{Each, Empty}
 import monocle.{Iso, PIso, PPrism, Prism}
 
 import scalaz.syntax.std.option._
@@ -23,12 +22,4 @@ trait MaybeOptics {
 
   final def nothing[A]: Prism[Maybe[A], Unit] =
     Prism[Maybe[A], Unit](m => if(m.isEmpty) Some(()) else None)(_ => Maybe.empty)
-
-  implicit def maybeEach[A]: Each[Maybe[A], A] = new Each[Maybe[A], A]{
-    def each = just.asTraversal
-  }
-
-  implicit def maybeEmpty[A]: Empty[Maybe[A]] = new Empty[Maybe[A]]{
-    def empty = nothing
-  }
 }

--- a/core/shared/src/main/scala/monocle/std/NonEmptyList.scala
+++ b/core/shared/src/main/scala/monocle/std/NonEmptyList.scala
@@ -1,9 +1,7 @@
 package monocle.std
 
-import monocle.function._
-import monocle.{Iso, Optional, PIso}
+import monocle.{Iso, PIso}
 
-import scalaz.NonEmptyList._
 import scalaz.{ICons, IList, INil, NonEmptyList, OneAnd}
 
 object nel extends NonEmptyListOptics
@@ -33,39 +31,4 @@ trait NonEmptyListOptics {
   @deprecated("use nelToOneAnd", since = "1.2.0")
   final def nelAndOneIso[A]: Iso[NonEmptyList[A], OneAnd[List,A]] =
     nelToOneAnd[A]
-
-
-  implicit def nelEach[A]: Each[NonEmptyList[A], A] =
-    Each.traverseEach[NonEmptyList, A]
-
-  implicit def nelIndex[A]: Index[NonEmptyList[A], Int, A] =
-    new Index[NonEmptyList[A], Int, A] {
-      def index(i: Int): Optional[NonEmptyList[A], A] = i match {
-        case 0 => nelCons1.head.asOptional
-        case _ => nelCons1.tail composeOptional list.listIndex.index(i-1)
-      }
-    }
-
-  implicit def nelFilterIndex[A]: FilterIndex[NonEmptyList[A], Int, A] =
-    FilterIndex.traverseFilterIndex[NonEmptyList, A](_.zipWithIndex)
-
-  implicit def nelReverse[A]: Reverse[NonEmptyList[A], NonEmptyList[A]] =
-    Reverse.reverseFromReverseFunction[NonEmptyList[A]](_.reverse)
-
-
-  implicit def nelCons1[A]: Cons1[NonEmptyList[A], A, List[A]] =
-    new Cons1[NonEmptyList[A],A,List[A]]{
-      def cons1: Iso[NonEmptyList[A], (A, List[A])] =
-        Iso((nel: NonEmptyList[A]) => (nel.head,nel.tail)){case (h,t) => NonEmptyList.nel(h, t)} composeIso
-          ilist.pIListToList.second
-    }
-
-  implicit def nelSnoc1[A]:Snoc1[NonEmptyList[A], List[A], A] =
-    new Snoc1[NonEmptyList[A],List[A], A]{
-      def snoc1: Iso[NonEmptyList[A], (List[A], A)] =
-        Iso((nel:NonEmptyList[A]) => nel.init -> nel.last){case (i,l) => NonEmptyList.nel(l, i.reverse).reverse} composeIso
-          ilist.pIListToList.first
-    }
-
-
 }

--- a/core/shared/src/main/scala/monocle/std/OneAnd.scala
+++ b/core/shared/src/main/scala/monocle/std/OneAnd.scala
@@ -1,36 +1,7 @@
 package monocle.std
 
-import monocle.function._
-import monocle.{Lens, Iso, Optional, Traversal}
+@deprecated("instances have been move to typeclass companion object", since = "1.4.0")
+object oneand
 
-import scalaz.{Applicative, Maybe, OneAnd}
-
-object oneand extends OneAndOptics
-
-trait OneAndOptics {
-
-  implicit def oneAndEach[T[_], A](implicit ev: Each[T[A], A]): Each[OneAnd[T, A], A] =
-    new Each[OneAnd[T, A], A]{
-      def each = new Traversal[OneAnd[T, A], A]{
-        def modifyF[F[_]: Applicative](f: A => F[A])(s: OneAnd[T, A]): F[OneAnd[T, A]] =
-          Applicative[F].apply2(f(s.head), ev.each.modifyF(f)(s.tail))((head, tail) => new OneAnd(head, tail))
-      }
-    }
-
-  implicit def oneAndIndex[T[_], A](implicit ev: Index[T[A], Int, A]): Index[OneAnd[T, A], Int, A] =
-    new Index[OneAnd[T, A], Int, A]{
-      def index(i: Int) = i match {
-        case 0 => oneAndCons1[T, A].head.asOptional
-        case _ => oneAndCons1[T, A].tail composeOptional ev.index(i - 1)
-      }
-    }
-
-  implicit def oneAndField1[T[_], A]: Field1[OneAnd[T, A], A] = new Field1[OneAnd[T, A], A]{
-    def first = Lens[OneAnd[T, A], A](_.head)(a => oneAnd => oneAnd.copy(head = a))
-  }
-
-  implicit def oneAndCons1[T[_], A]: Cons1[OneAnd[T, A], A, T[A]] = new Cons1[OneAnd[T, A], A, T[A]] {
-    def cons1 = Iso[OneAnd[T, A], (A, T[A])](o => (o.head, o.tail)){ case (h, t) => OneAnd(h, t)}
-  }
-
-}
+@deprecated("instances have been move to typeclass companion object", since = "1.4.0")
+trait OneAndOptics

--- a/core/shared/src/main/scala/monocle/std/Option.scala
+++ b/core/shared/src/main/scala/monocle/std/Option.scala
@@ -1,14 +1,12 @@
 package monocle.std
 
-import monocle.function._
-import monocle.{PPrism, Prism, PIso, Iso}
+import monocle.{Iso, PIso, PPrism, Prism}
 
-import scalaz.{-\/, \/-, \/}
+import scalaz.{-\/, \/, \/-}
 
 object option extends OptionOptics
 
 trait OptionOptics {
-
   final def pSome[A, B]: PPrism[Option[A], Option[B], A, B] =
     PPrism[Option[A], Option[B], A, B](_.map(\/-(_)) getOrElse -\/(None))(Some.apply)
 
@@ -23,14 +21,5 @@ trait OptionOptics {
 
   final def optionToDisjunction[A]: Iso[Option[A], Unit \/ A] =
     pOptionToDisjunction[A, A]
-
-  implicit def optionEmpty[A]: Empty[Option[A]] = new Empty[Option[A]] {
-    def empty = none
-  }
-
-  implicit def optEach[A]: Each[Option[A], A] = new Each[Option[A], A] {
-    def each = some.asTraversal
-  }
-
 }
 

--- a/core/shared/src/main/scala/monocle/std/Set.scala
+++ b/core/shared/src/main/scala/monocle/std/Set.scala
@@ -1,18 +1,7 @@
 package monocle.std
 
-import monocle.function.{At, Empty}
-import monocle.{Lens, Prism}
+@deprecated("instances have been move to typeclass companion object", since = "1.4.0")
+object set
 
-object set extends SetOptics
-
-trait SetOptics {
-
-  implicit def emptySet[A]: Empty[Set[A]] = new Empty[Set[A]] {
-    def empty = Prism[Set[A], Unit](s => if(s.isEmpty) Some(()) else None)(_ => Set.empty[A])
-  }
-
-  implicit def atSet[A]: At[Set[A], A, Boolean] = new At[Set[A], A, Boolean] {
-    def at(a: A) = Lens[Set[A], Boolean](_.contains(a))(b => set => if(b) set + a else set - a)
-  }
-
-}
+@deprecated("instances have been move to typeclass companion object", since = "1.4.0")
+trait SetOptics

--- a/core/shared/src/main/scala/monocle/std/Stream.scala
+++ b/core/shared/src/main/scala/monocle/std/Stream.scala
@@ -1,65 +1,7 @@
 package monocle.std
 
-import monocle.function._
-import monocle.{Optional, Prism, Traversal}
+@deprecated("instances have been move to typeclass companion object", since = "1.4.0")
+object stream
 
-import scala.collection.immutable.Stream.{#::, Empty}
-import scalaz.Applicative
-import scalaz.Id.Id
-import scalaz.std.stream._
-import scalaz.syntax.traverse._
-
-object stream extends StreamOptics
-
-trait StreamOptics {
-
-  implicit def streamEmpty[A]: Empty[Stream[A]] = new Empty[Stream[A]] {
-    def empty = Prism[Stream[A], Unit](s => if(s.isEmpty) Some(()) else None)(_ => Stream.empty)
-  }
-
-  implicit def streamEach[A]: Each[Stream[A], A] = Each.traverseEach[Stream, A]
-
-  implicit def streamIndex[A]: Index[Stream[A], Int, A] = new Index[Stream[A], Int, A] {
-    def index(i: Int) = Optional[Stream[A], A](
-      s      => if(i < 0) None else s.drop(i).headOption)(
-      a => s => s.zipWithIndex.traverse[Id, A]{
-        case (_    , index) if index == i => a
-        case (value, index)               => value
-      }
-    )
-  }
-
-  implicit def streamFilterIndex[A]: FilterIndex[Stream[A], Int, A] =
-    FilterIndex.traverseFilterIndex[Stream, A](_.zipWithIndex)
-
-  implicit def streamCons[A]: Cons[Stream[A], A] = new Cons[Stream[A], A]{
-    def cons = Prism[Stream[A], (A, Stream[A])]{
-      case Empty    => None
-      case x #:: xs => Some((x, xs))
-    }{ case (a, s) => a #:: s }
-  }
-
-  implicit def streamSnoc[A]: Snoc[Stream[A], A] = new Snoc[Stream[A], A]{
-    def snoc = Prism[Stream[A], (Stream[A], A)]( s =>
-      for {
-        init <- if(s.isEmpty) None else Some(s.init)
-        last <- s.lastOption
-      } yield (init, last)){
-      case (init, last) => init :+ last
-    }
-  }
-
-  implicit def streamReverse[A]: Reverse[Stream[A], Stream[A]] =
-    Reverse.reverseFromReverseFunction[Stream[A]](_.reverse)
-
-  implicit def streamPlated[A]: Plated[Stream[A]] = new Plated[Stream[A]] {
-    val plate: Traversal[Stream[A], Stream[A]] = new Traversal[Stream[A], Stream[A]] {
-      def modifyF[F[_]: Applicative](f: Stream[A] => F[Stream[A]])(s: Stream[A]): F[Stream[A]] =
-        s match {
-          case x #:: xs => Applicative[F].map(f(xs))(x #:: _)
-          case Stream() => Applicative[F].point(Stream.empty)
-        }
-    }
-  }
-
-}
+@deprecated("instances have been move to typeclass companion object", since = "1.4.0")
+trait StreamOptics

--- a/core/shared/src/main/scala/monocle/std/String.scala
+++ b/core/shared/src/main/scala/monocle/std/String.scala
@@ -1,10 +1,7 @@
 package monocle.std
 
-import monocle.function._
-import monocle.std.list._
-import monocle.{Iso, Prism, Traversal}
+import monocle.{Iso, Prism}
 
-import scalaz.Applicative
 import scalaz.std.list._
 import scalaz.std.option._
 import scalaz.syntax.traverse._
@@ -27,59 +24,6 @@ trait StringOptics {
 
   val stringToByte: Prism[String, Byte] =
     stringToLong composePrism long.longToByte
-
-
-  implicit val stringEmpty: Empty[String] =
-    new Empty[String] {
-      def empty = Prism[String, Unit](s => if(s.isEmpty) Some(()) else None)(_ => "")
-    }
-
-  implicit val stringReverse: Reverse[String, String] =
-    Reverse.reverseFromReverseFunction[String](_.reverse)
-
-  implicit val stringEach: Each[String, Char] =
-    new Each[String, Char] {
-      def each =
-        stringToList composeTraversal Each.each[List[Char], Char]
-    }
-
-  implicit val stringIndex: Index[String, Int, Char] =
-    new Index[String, Int, Char]{
-      def index(i: Int) =
-        stringToList composeOptional Index.index[List[Char], Int, Char](i)
-    }
-
-  implicit val stringFilterIndex: FilterIndex[String, Int, Char] =
-    new FilterIndex[String, Int, Char]{
-      def filterIndex(predicate: Int => Boolean) =
-        stringToList composeTraversal FilterIndex.filterIndex[List[Char], Int, Char](predicate)
-    }
-
-  implicit val stringCons: Cons[String, Char] =
-    new Cons[String, Char] {
-      def cons =
-        Prism[String, (Char, String)](s =>
-          if(s.isEmpty) None else Some((s.head, s.tail))
-        ){ case (h, t) => h + t }
-  }
-
-  implicit val stringSnoc: Snoc[String, Char] = new Snoc[String, Char]{
-    def snoc =
-      Prism[String, (String, Char)](
-        s => if(s.isEmpty) None else Some((s.init, s.last))){
-        case (init, last) => init :+ last
-      }
-  }
-
-  implicit val stringPlated: Plated[String] = new Plated[String] {
-    val plate: Traversal[String, String] = new Traversal[String, String] {
-      def modifyF[F[_]: Applicative](f: String => F[String])(s: String): F[String] =
-        s.headOption match {
-          case Some(h) => Applicative[F].map(f(s.tail))(h.toString ++ _)
-          case None => Applicative[F].point("")
-        }
-    }
-  }
 
   private def parseLong(s: String): Option[Long] = {
     // we reject cases where String will be an invalid Prism according 2nd Prism law

--- a/core/shared/src/main/scala/monocle/std/Tag.scala
+++ b/core/shared/src/main/scala/monocle/std/Tag.scala
@@ -1,16 +1,7 @@
 package monocle.std
 
-import monocle.Iso
-import monocle.function.Wrapped
+@deprecated("instances have been move to typeclass companion object", since = "1.4.0")
+object tag
 
-import scalaz.{@@, Tag}
-
-object tag extends TagOptics
-
-trait TagOptics {
-  implicit def tagWrapped[A, B]: Wrapped[A @@ B, A] =
-    new Wrapped[A @@ B, A] {
-      val wrapped: Iso[A @@ B, A] =
-        Iso(Tag.unwrap[A, B])(Tag.apply)
-    }
-}
+@deprecated("instances have been move to typeclass companion object", since = "1.4.0")
+trait TagOptics

--- a/core/shared/src/main/scala/monocle/std/Tree.scala
+++ b/core/shared/src/main/scala/monocle/std/Tree.scala
@@ -1,15 +1,12 @@
 package monocle.std
 
-import monocle.function._
-import monocle.{Iso, Lens, Traversal}
+import monocle.Lens
 import monocle.function.all._
-import monocle.std.stream._
 
-import scalaz.Tree.{Leaf, Node}
-import scalaz.{Applicative, Traverse, Tree}
-import scalaz.std.stream._
 import scala.annotation.tailrec
 import scala.collection.immutable.Stream.Empty
+import scalaz.Tree
+import scalaz.Tree.{Leaf, Node}
 
 object tree extends TreeOptics
 
@@ -49,20 +46,6 @@ trait TreeOptics {
     }
 
     Lens(_get)(_set)
-  }
-
-  implicit def treeEach[A]: Each[Tree[A], A] = Each.traverseEach[Tree, A]
-
-  implicit def treeReverse[A]: Reverse[Tree[A], Tree[A]] = new Reverse[Tree[A], Tree[A]] {
-    def reverse = Iso[Tree[A], Tree[A]](reverseTree)(reverseTree)
-    private def reverseTree(tree: Tree[A]): Tree[A] = Node(tree.rootLabel, tree.subForest.reverse.map(reverseTree))
-  }
-
-  implicit def treePlated[A]: Plated[Tree[A]] = new Plated[Tree[A]] {
-    val plate: Traversal[Tree[A], Tree[A]] = new Traversal[Tree[A], Tree[A]] {
-      def modifyF[F[_]: Applicative](f: Tree[A] => F[Tree[A]])(s: Tree[A]): F[Tree[A]] =
-        Applicative[F].map(Traverse[Stream].traverse(s.subForest)(f))(Node(s.rootLabel, _))
-    }
   }
 
 }

--- a/core/shared/src/main/scala/monocle/std/Tuple1.scala
+++ b/core/shared/src/main/scala/monocle/std/Tuple1.scala
@@ -1,20 +1,9 @@
 package monocle.std
 
-import monocle.function._
-import monocle.{Iso, Lens}
+import monocle.Iso
 
 object tuple1 extends Tuple1Optics
 
 trait Tuple1Optics {
-
   def tuple1Iso[A]: Iso[Tuple1[A], A] = Iso[Tuple1[A], A](_._1)(Tuple1.apply)
-
-  implicit def tuple1Field1[A]: Field1[Tuple1[A], A] = new Field1[Tuple1[A], A] {
-    def first = Lens((_: Tuple1[A])._1)(a => _ => Tuple1(a))
-  }
-
-  implicit def tuple1Reverse[A]: Reverse[Tuple1[A], Tuple1[A]] = new Reverse[Tuple1[A], Tuple1[A]] {
-    def reverse = Iso.id
-  }
-
 }

--- a/core/shared/src/main/scala/monocle/std/Tuple2.scala
+++ b/core/shared/src/main/scala/monocle/std/Tuple2.scala
@@ -1,35 +1,7 @@
 package monocle.std
 
-import monocle.function._
-import monocle.{Iso, Lens, PTraversal}
+@deprecated("instances have been move to typeclass companion object", since = "1.4.0")
+object tuple2
 
-object tuple2 extends Tuple2Optics
-
-trait Tuple2Optics {
-
-  implicit def tuple2Each[A]: Each[(A, A), A] = new Each[(A, A), A] {
-    def each =
-      PTraversal.apply2[(A, A), (A, A), A, A](_._1,_._2)((b1, b2, _) => (b1, b2))
-  }
-
-  implicit def tuple2Field1[A1, A2]: Field1[(A1, A2), A1] = new Field1[(A1, A2), A1] {
-    def first = Lens((_: (A1, A2))._1)(a => t => t.copy(_1 = a))
-  }
-
-  implicit def tuple2Field2[A1, A2]: Field2[(A1, A2), A2]  = new Field2[(A1, A2), A2] {
-    def second = Lens((_: (A1, A2))._2)(a => t => t.copy(_2 = a))
-  }
-
-  implicit def tuple2Cons1[A1, A2]: Cons1[(A1, A2), A1, A2] = new Cons1[(A1, A2), A1, A2] {
-    def cons1 = Iso[(A1, A2), (A1, A2)](identity)(identity)
-  }
-
-  implicit def tuple2Snoc1[A1, A2]: Snoc1[(A1, A2), A1, A2] = new Snoc1[(A1, A2), A1, A2] {
-    def snoc1 = Iso[(A1, A2), (A1, A2)](identity)(identity)
-  }
-
-  implicit def tuple2Reverse[A, B]: Reverse[(A, B), (B, A)] = new Reverse[(A, B), (B, A)] {
-    def reverse = Iso[(A, B), (B, A)](_.swap)(_.swap)
-  }
-
-}
+@deprecated("instances have been move to typeclass companion object", since = "1.4.0")
+trait Tuple2Optics

--- a/core/shared/src/main/scala/monocle/std/Tuple3.scala
+++ b/core/shared/src/main/scala/monocle/std/Tuple3.scala
@@ -3,37 +3,8 @@ package monocle.std
 import monocle.{Iso, Lens, PTraversal}
 import monocle.function._
 
-object tuple3 extends Tuple3Optics
+@deprecated("instances have been move to typeclass companion object", since = "1.4.0")
+object tuple3
 
-trait Tuple3Optics {
-
-  implicit def tuple3Each[A]: Each[(A, A, A), A] = new Each[(A, A, A), A] {
-    def each =
-      PTraversal.apply3[(A, A, A), (A, A, A), A, A](_._1,_._2,_._3)((b1, b2, b3, _) => (b1, b2, b3))
-  }
-
-  implicit def tuple3Field1[A1, A2, A3]: Field1[(A1, A2, A3), A1] = new Field1[(A1, A2, A3), A1] {
-    def first = Lens((_: (A1, A2, A3))._1)(a => t => t.copy(_1 = a))
-  }
-
-  implicit def tuple3Field2[A1, A2, A3]: Field2[(A1, A2, A3), A2] = new Field2[(A1, A2, A3), A2] {
-    def second = Lens((_: (A1, A2, A3))._2)(a => t => t.copy(_2 = a))
-  }
-
-  implicit def tuple3Field3[A1, A2, A3]: Field3[(A1, A2, A3), A3] = new Field3[(A1, A2, A3), A3] {
-    def third = Lens((_: (A1, A2, A3))._3)(a => t => t.copy(_3 = a))
-  }
-
-  implicit def tuple3Cons1[A1, A2, A3]: Cons1[(A1, A2, A3), A1, (A2, A3)] = new Cons1[(A1, A2, A3), A1, (A2, A3)] {
-    def cons1 = Iso[(A1, A2, A3), (A1, (A2, A3))](t => (t._1, (t._2, t._3))){ case (h, t) => (h, t._1, t._2) }
-  }
-
-  implicit def tuple3Snoc1[A1, A2, A3]: Snoc1[(A1, A2, A3), (A1, A2), A3] = new Snoc1[(A1, A2, A3), (A1, A2), A3]{
-    def snoc1 = Iso[(A1, A2, A3), ((A1, A2), A3)](t => ((t._1, t._2), t._3)){ case (i, l) => (i._1, i._2, l) }
-  }
-
-  implicit def tuple3Reverse[A, B, C]: Reverse[(A, B, C), (C, B, A)] = new Reverse[(A, B, C), (C, B, A)] {
-    def reverse = Iso{t: (A, B, C) => (t._3, t._2, t._1)}(t => (t._3, t._2, t._1))
-  }
-
-}
+@deprecated("instances have been move to typeclass companion object", since = "1.4.0")
+trait Tuple3Optics

--- a/core/shared/src/main/scala/monocle/std/Tuple4.scala
+++ b/core/shared/src/main/scala/monocle/std/Tuple4.scala
@@ -3,41 +3,8 @@ package monocle.std
 import monocle.{Iso, Lens, PTraversal}
 import monocle.function._
 
-object tuple4 extends Tuple4Optics
+@deprecated("instances have been move to typeclass companion object", since = "1.4.0")
+object tuple4
 
-trait Tuple4Optics {
-
-  implicit def tuple4Each[A]: Each[(A, A, A, A), A] = new Each[(A, A, A, A), A] {
-    def each =
-      PTraversal.apply4[(A, A, A, A), (A, A, A, A), A, A](_._1,_._2,_._3,_._4)((b1, b2, b3, b4, _) => (b1, b2, b3, b4))
-  }
-
-  implicit def tuple4Field1[A1, A2, A3, A4]: Field1[(A1, A2, A3, A4), A1] = new Field1[(A1, A2, A3, A4), A1] {
-    def first = Lens((_: (A1, A2, A3, A4))._1)(a => t => t.copy(_1 = a))
-  }
-
-  implicit def tuple4Field2[A1, A2, A3, A4]: Field2[(A1, A2, A3, A4), A2] = new Field2[(A1, A2, A3, A4), A2] {
-    def second = Lens((_: (A1, A2, A3, A4))._2)(a => t => t.copy(_2 = a))
-  }
-
-  implicit def tuple4Field3[A1, A2, A3, A4]: Field3[(A1, A2, A3, A4), A3]  = new Field3[(A1, A2, A3, A4), A3] {
-    def third = Lens((_: (A1, A2, A3, A4))._3)(a => t => t.copy(_3 = a))
-  }
-
-  implicit def tuple4Field4[A1, A2, A3, A4]: Field4[(A1, A2, A3, A4), A4] = new Field4[(A1, A2, A3, A4), A4] {
-    def fourth = Lens((_: (A1, A2, A3, A4))._4)(a => t => t.copy(_4 = a))
-  }
-
-  implicit def tuple4Cons1[A1, A2, A3, A4]: Cons1[(A1, A2, A3, A4), A1, (A2, A3, A4)] = new Cons1[(A1, A2, A3, A4), A1, (A2, A3, A4)]{
-    def cons1 = Iso[(A1, A2, A3, A4), (A1, (A2, A3, A4))](t => (t._1, (t._2, t._3, t._4))){ case (h, t) => (h, t._1, t._2, t._3) }
-  }
-
-  implicit def tuple4Snoc1[A1, A2, A3, A4]: Snoc1[(A1, A2, A3, A4), (A1, A2, A3), A4] = new Snoc1[(A1, A2, A3, A4), (A1, A2, A3), A4]{
-    def snoc1 = Iso[(A1, A2, A3, A4), ((A1, A2, A3), A4)](t => ((t._1, t._2, t._3), t._4)){ case (i, l) => (i._1, i._2, i._3, l) }
-  }
-
-  implicit def tuple4Reverse[A, B, C, D]: Reverse[(A, B, C, D), (D, C, B, A)] = new Reverse[(A, B, C, D), (D, C, B, A)] {
-    def reverse = Iso{t: (A, B, C, D) => (t._4, t._3, t._2, t._1)}(t => (t._4, t._3, t._2, t._1))
-  }
-
-}
+@deprecated("instances have been move to typeclass companion object", since = "1.4.0")
+trait Tuple4Optics

--- a/core/shared/src/main/scala/monocle/std/Tuple5.scala
+++ b/core/shared/src/main/scala/monocle/std/Tuple5.scala
@@ -1,47 +1,7 @@
 package monocle.std
 
-import monocle.function._
-import monocle.{Iso, Lens, PTraversal}
+@deprecated("instances have been move to typeclass companion object", since = "1.4.0")
+object tuple5
 
-object tuple5 extends Tuple5Optics
-
-trait Tuple5Optics {
-
-  implicit def tuple5Each[A]: Each[(A, A, A, A, A), A] = new Each[(A, A, A, A, A), A] {
-    def each =
-      PTraversal.apply5[(A, A, A, A, A), (A, A, A, A, A), A, A](_._1,_._2,_._3,_._4,_._5)((b1, b2, b3, b4, b5, _) => (b1, b2, b3, b4, b5))
-  }
-
-  implicit def tuple5Field1[A1, A2, A3, A4, A5]: Field1[(A1, A2, A3, A4, A5), A1] = new Field1[(A1, A2, A3, A4, A5), A1] {
-    def first = Lens((_: (A1, A2, A3, A4, A5))._1)(a => t => t.copy(_1 = a))
-  }
-
-  implicit def tuple5Field2[A1, A2, A3, A4, A5]: Field2[(A1, A2, A3, A4, A5), A2] = new Field2[(A1, A2, A3, A4, A5), A2] {
-    def second = Lens((_: (A1, A2, A3, A4, A5))._2)(a => t => t.copy(_2 = a))
-  }
-
-  implicit def tuple5Field3[A1, A2, A3, A4, A5]: Field3[(A1, A2, A3, A4, A5), A3] = new Field3[(A1, A2, A3, A4, A5), A3] {
-    def third = Lens((_: (A1, A2, A3, A4, A5))._3)(a => t => t.copy(_3 = a))
-  }
-
-  implicit def tuple5Field4[A1, A2, A3, A4, A5]: Field4[(A1, A2, A3, A4, A5), A4] = new Field4[(A1, A2, A3, A4, A5), A4] {
-    def fourth = Lens((_: (A1, A2, A3, A4, A5))._4)(a => t => t.copy(_4 = a))
-  }
-
-  implicit def tuple5Field5[A1, A2, A3, A4, A5]: Field5[(A1, A2, A3, A4, A5), A5] = new Field5[(A1, A2, A3, A4, A5), A5] {
-    def fifth = Lens((_: (A1, A2, A3, A4, A5))._5)(a => t => t.copy(_5 = a))
-  }
-
-  implicit def tuple5Cons1[A1, A2, A3, A4, A5]: Cons1[(A1, A2, A3, A4, A5), A1, (A2, A3, A4, A5)] = new Cons1[(A1, A2, A3, A4, A5), A1, (A2, A3, A4, A5)]{
-    def cons1 = Iso[(A1, A2, A3, A4, A5), (A1, (A2, A3, A4, A5))](t => (t._1, (t._2, t._3, t._4, t._5))){ case (h, t) => (h, t._1, t._2, t._3, t._4) }
-  }
-
-  implicit def tuple5Snoc1[A1, A2, A3, A4, A5]: Snoc1[(A1, A2, A3, A4, A5), (A1, A2, A3, A4), A5] = new Snoc1[(A1, A2, A3, A4, A5), (A1, A2, A3, A4), A5]{
-    def snoc1 = Iso[(A1, A2, A3, A4, A5), ((A1, A2, A3, A4), A5)](t => ((t._1, t._2, t._3, t._4), t._5)){ case (i, l) => (i._1, i._2, i._3, i._4, l) }
-  }
-
-  implicit def tuple5Reverse[A, B, C, D, E]: Reverse[(A, B, C, D, E), (E, D, C, B, A)] = new Reverse[(A, B, C, D, E), (E, D, C, B, A)] {
-    def reverse = Iso{t: (A, B, C, D, E) => (t._5, t._4, t._3, t._2, t._1)}(t => (t._5, t._4, t._3, t._2, t._1))
-  }
-
-}
+@deprecated("instances have been move to typeclass companion object", since = "1.4.0")
+trait Tuple5Optics

--- a/core/shared/src/main/scala/monocle/std/Tuple6.scala
+++ b/core/shared/src/main/scala/monocle/std/Tuple6.scala
@@ -1,50 +1,7 @@
 package monocle.std
 
-import monocle.function._
-import monocle.{Iso, Lens, PTraversal}
+@deprecated("instances have been move to typeclass companion object", since = "1.4.0")
+object tuple6
 
-object tuple6 extends Tuple6Optics
-
-trait Tuple6Optics {
-
-  implicit def tuple6Each[A]: Each[(A, A, A, A, A, A), A] = new Each[(A, A, A, A, A, A), A] {
-    def each =
-      PTraversal.apply6[(A, A, A, A, A, A), (A, A, A, A, A, A), A, A](_._1,_._2,_._3,_._4,_._5, _._6)((b1, b2, b3, b4, b5, b6, _) => (b1, b2, b3, b4, b5, b6))
-  }
-
-  implicit def tuple6Field1[A1, A2, A3, A4, A5, A6]: Field1[(A1, A2, A3, A4, A5, A6), A1] = new Field1[(A1, A2, A3, A4, A5, A6), A1] {
-    def first = Lens((_: (A1, A2, A3, A4, A5, A6))._1)(a => t => t.copy(_1 = a))
-  }
-
-  implicit def tuple6Field2[A1, A2, A3, A4, A5, A6]: Field2[(A1, A2, A3, A4, A5, A6), A2] = new Field2[(A1, A2, A3, A4, A5, A6), A2] {
-    def second = Lens((_: (A1, A2, A3, A4, A5, A6))._2)(a => t => t.copy(_2 = a))
-  }
-
-  implicit def tuple6Field3[A1, A2, A3, A4, A5, A6]: Field3[(A1, A2, A3, A4, A5, A6), A3] = new Field3[(A1, A2, A3, A4, A5, A6), A3] {
-    def third = Lens((_: (A1, A2, A3, A4, A5, A6))._3)(a => t => t.copy(_3 = a))
-  }
-
-  implicit def tuple6Field4[A1, A2, A3, A4, A5, A6]: Field4[(A1, A2, A3, A4, A5, A6), A4] = new Field4[(A1, A2, A3, A4, A5, A6), A4] {
-    def fourth = Lens((_: (A1, A2, A3, A4, A5, A6))._4)(a => t => t.copy(_4 = a))
-  }
-
-  implicit def tuple6Field5[A1, A2, A3, A4, A5, A6]: Field5[(A1, A2, A3, A4, A5, A6), A5] = new Field5[(A1, A2, A3, A4, A5, A6), A5] {
-    def fifth = Lens((_: (A1, A2, A3, A4, A5, A6))._5)(a => t => t.copy(_5 = a))
-  }
-
-  implicit def tuple6Field6[A1, A2, A3, A4, A5, A6]: Field6[(A1, A2, A3, A4, A5, A6), A6] = new Field6[(A1, A2, A3, A4, A5, A6), A6] {
-    def sixth = Lens((_: (A1, A2, A3, A4, A5, A6))._6)(a => t => t.copy(_6 = a))
-  }
-
-  implicit def tuple6Cons1[A1, A2, A3, A4, A5, A6]: Cons1[(A1, A2, A3, A4, A5, A6), A1, (A2, A3, A4, A5, A6)] = new Cons1[(A1, A2, A3, A4, A5, A6), A1, (A2, A3, A4, A5, A6)]{
-    def cons1 = Iso[(A1, A2, A3, A4, A5, A6), (A1, (A2, A3, A4, A5, A6))](t => (t._1, (t._2, t._3, t._4, t._5, t._6))){ case (h, t) => (h, t._1, t._2, t._3, t._4, t._5) }
-  }
-
-  implicit def tuple6Snoc1[A1, A2, A3, A4, A5, A6]: Snoc1[(A1, A2, A3, A4, A5, A6), (A1, A2, A3, A4, A5), A6] = new Snoc1[(A1, A2, A3, A4, A5, A6), (A1, A2, A3, A4, A5), A6]{
-    def snoc1 = Iso[(A1, A2, A3, A4, A5, A6), ((A1, A2, A3, A4, A5), A6)](t => ((t._1, t._2, t._3, t._4, t._5), t._6)){ case (i, l) => (i._1, i._2, i._3, i._4, i._5, l) }
-  }
-
-  implicit def tuple6Reverse[A, B, C, D, E, F]: Reverse[(A, B, C, D, E, F), (F, E, D, C, B, A)] = new Reverse[(A, B, C, D, E, F), (F, E, D, C, B, A)] {
-    def reverse = Iso{t: (A, B, C, D, E, F) => (t._6, t._5, t._4, t._3, t._2, t._1)}(t => (t._6, t._5, t._4, t._3, t._2, t._1))
-  }
-}
+@deprecated("instances have been move to typeclass companion object", since = "1.4.0")
+trait Tuple6Optics

--- a/core/shared/src/main/scala/monocle/std/Vector.scala
+++ b/core/shared/src/main/scala/monocle/std/Vector.scala
@@ -1,56 +1,7 @@
 package monocle.std
 
-import monocle.function._
-import monocle.{Optional, Prism, Traversal}
+@deprecated("instances have been move to typeclass companion object", since = "1.4.0")
+object vector
 
-import scalaz.Applicative
-import scalaz.std.vector._
-
-object vector extends VectorOptics
-
-trait VectorOptics {
-
-  implicit def vectorEmpty[A]: Empty[Vector[A]] = new Empty[Vector[A]] {
-    def empty = Prism[Vector[A], Unit](v => if(v.isEmpty) Some(()) else None)(_ => Vector.empty)
-  }
-
-  implicit def vectorEach[A]: Each[Vector[A], A] = Each.traverseEach[Vector, A]
-
-  implicit def vectorIndex[A]: Index[Vector[A], Int, A] = new Index[Vector[A], Int, A] {
-    def index(i: Int) =
-      Optional[Vector[A], A](v =>
-        if(v.isDefinedAt(i)) Some(v(i))     else None)(a => v =>
-        if(v.isDefinedAt(i)) v.updated(i,a) else v)
-  }
-
-  implicit def vectorFilterIndex[A]: FilterIndex[Vector[A], Int, A] =
-    FilterIndex.traverseFilterIndex[Vector, A](_.zipWithIndex)
-
-  implicit def vectorCons[A]: Cons[Vector[A], A] = new Cons[Vector[A], A]{
-    def cons = Prism[Vector[A], (A, Vector[A])]{
-      case Vector() => None
-      case x +: xs  => Some((x, xs))
-    }{ case (a, s) => a +: s }
-  }
-
-  implicit def vectorSnoc[A]: Snoc[Vector[A], A] = new Snoc[Vector[A], A]{
-    def snoc = Prism[Vector[A], (Vector[A], A)](
-      v => if(v.isEmpty) None else Some((v.init, v.last))){
-      case (xs, x) => xs :+ x
-    }
-  }
-
-  implicit def vectorReverse[A]: Reverse[Vector[A], Vector[A]] =
-    Reverse.reverseFromReverseFunction[Vector[A]](_.reverse)
-
-  implicit def vectorPlated[A]: Plated[Vector[A]] = new Plated[Vector[A]] {
-    val plate: Traversal[Vector[A], Vector[A]] = new Traversal[Vector[A], Vector[A]] {
-      def modifyF[F[_]: Applicative](f: Vector[A] => F[Vector[A]])(s: Vector[A]): F[Vector[A]] =
-        s match {
-          case h +: t => Applicative[F].map(f(t))(h +: _)
-          case _ => Applicative[F].point(Vector.empty)
-        }
-    }
-  }
-
-}
+@deprecated("instances have been move to typeclass companion object", since = "1.4.0")
+trait VectorOptics

--- a/docs/src/main/tut/faq.md
+++ b/docs/src/main/tut/faq.md
@@ -27,39 +27,26 @@ or you can import all typeclass based optics with
 import monocle.function.all._
 ```
 
-Now, if you try to use `headOption` you will see the following error:
+Here is a complete example
 
 ```tut:silent
+import monocle.function.all._
+import monocle.macros.GenLens
+
 case class Foo(s: String, is: List[Int])
 val foo = Foo("Hello", List(1,2,3))
 
-import monocle.macros.GenLens
 val is = GenLens[Foo](_.is)
 ```
 
-```tut:fail
+```tut:book
 (is composeOptional headOption).getOption(foo)
 ```
 
-It means there is no instance of `Cons` (the typeclass where `headOption` is defined) for `List` in scope. You 
-could also get a more esoteric error message in case you have some `Cons` instance in scope that are not for `List`
-
-```tut:silent
-import monocle.std.vector._
-```
-
-```tut:fail
-(is composeOptional headOption).getOption(foo)
-```
-
-In our case, we need the `List` instance for `Cons` which can be obtained with the following import
+Note: if you use a version of monocle before 1.4.x, you need another import to get the typeclass instance
 
 ```tut:silent
 import monocle.std.list._
-```
-
-```tut
-(is composeOptional headOption).getOption(foo)
 ```
 
 ## What is the difference between at and index? When should I use one or the other?
@@ -76,7 +63,7 @@ val m = Map("one" -> 1, "two" -> 2)
 val root = Iso.id[Map[String, Int]]
 ```
 
-```tut
+```tut:book
 (root composeOptional index("two")).set(0)(m)   // update value at index "two"
 (root composeOptional index("three")).set(3)(m) // noop because m doesn't have a value at "three"
 (root composeLens at("three")).set(Some(3))(m)  // insert element at "three"
@@ -103,6 +90,6 @@ Similarly, if the `Map` was in a case class, a `Lens` would provide the same kin
 ```tut:silent
 case class Bar(kv: Map[String, Int])
 ```
-```tut
+```tut:book
 (GenLens[Bar](_.kv) composeOptional index("two")).set(0)(Bar(m))
 ```

--- a/example/src/test/scala/monocle/function/EmptyExample.scala
+++ b/example/src/test/scala/monocle/function/EmptyExample.scala
@@ -26,8 +26,8 @@ class EmptyExample extends MonocleSuite {
     _isEmpty(List(1,2,3)) shouldEqual false
     _isEmpty("hello")     shouldEqual false
 
-    _isEmpty(Nil)  shouldEqual true
-    _isEmpty("")   shouldEqual true
+    _isEmpty(List.empty)  shouldEqual true
+    _isEmpty("")          shouldEqual true
   }
   
 }

--- a/law/shared/src/main/scala/monocle/law/discipline/function/AtTests.scala
+++ b/law/shared/src/main/scala/monocle/law/discipline/function/AtTests.scala
@@ -11,7 +11,7 @@ import scalaz.Equal
 object AtTests extends Laws {
 
   def apply[S: Equal : Arbitrary, I: Arbitrary, A: Equal : Arbitrary](implicit evAt: At[S, I, A], arbAA: Arbitrary[A => A]): RuleSet = {
-    new SimpleRuleSet("At", LensTests(at(_: I)).props: _*)
+    new SimpleRuleSet("At", LensTests(at(_: I)(evAt)).props: _*)
   }
 
 }

--- a/law/shared/src/main/scala/monocle/law/discipline/function/FilterIndexTests.scala
+++ b/law/shared/src/main/scala/monocle/law/discipline/function/FilterIndexTests.scala
@@ -12,7 +12,7 @@ object FilterIndexTests extends Laws {
 
   def apply[S: Equal : Arbitrary, I, A: Equal : Arbitrary](implicit evFilterIndex: FilterIndex[S, I, A],
                                                                     arbAA: Arbitrary[A => A], arbIB: Arbitrary[I => Boolean]): RuleSet =
-    new SimpleRuleSet("FilterIndex", TraversalTests(filterIndex(_: I => Boolean)).props: _*)
+    new SimpleRuleSet("FilterIndex", TraversalTests(filterIndex(_: I => Boolean)(evFilterIndex)).props: _*)
 
 
 }

--- a/law/shared/src/main/scala/monocle/law/discipline/function/IndexTests.scala
+++ b/law/shared/src/main/scala/monocle/law/discipline/function/IndexTests.scala
@@ -12,6 +12,6 @@ object IndexTests extends Laws {
 
   def apply[S: Equal : Arbitrary, I : Arbitrary, A: Equal : Arbitrary](implicit evIndex: Index[S, I, A],
                                                                        arbAA: Arbitrary[A => A]): RuleSet =
-    new SimpleRuleSet("Index", OptionalTests(index(_ : I)).props: _*)
+    new SimpleRuleSet("Index", OptionalTests(index(_ : I)(evIndex)).props: _*)
 
 }

--- a/test/shared/src/test/scala/monocle/function/Cons1Spec.scala
+++ b/test/shared/src/test/scala/monocle/function/Cons1Spec.scala
@@ -3,12 +3,12 @@ package monocle.function
 import monocle.MonocleSuite
 import monocle.law.discipline.function.Cons1Tests
 
-import scalaz.NonEmptyList
+import scalaz.IList
 
 class Cons1Spec extends MonocleSuite {
 
-  implicit val clistCons1: Cons1[CNel, Char, List[Char]] = Cons1.fromIso(CNel.toNel)
+  implicit val clistCons1: Cons1[CNel, Char, IList[Char]] = Cons1.fromIso(CNel.toNel)
 
-  checkAll("fromIso", Cons1Tests[CNel, Char, List[Char]])
+  checkAll("fromIso", Cons1Tests[CNel, Char, IList[Char]])
 
 }

--- a/test/shared/src/test/scala/monocle/function/Snoc1Spec.scala
+++ b/test/shared/src/test/scala/monocle/function/Snoc1Spec.scala
@@ -3,10 +3,12 @@ package monocle.function
 import monocle.MonocleSuite
 import monocle.law.discipline.function.Snoc1Tests
 
+import scalaz.IList
+
 class Snoc1Spec extends MonocleSuite {
 
-  implicit val clistSnoc1: Snoc1[CNel, List[Char], Char] = Snoc1.fromIso(CNel.toNel)
+  implicit val clistSnoc1: Snoc1[CNel, IList[Char], Char] = Snoc1.fromIso(CNel.toNel)
 
-  checkAll("fromIso", Snoc1Tests[CNel, List[Char], Char])
+  checkAll("fromIso", Snoc1Tests[CNel, IList[Char], Char])
 
 }

--- a/test/shared/src/test/scala/monocle/std/NonEmptyListSpec.scala
+++ b/test/shared/src/test/scala/monocle/std/NonEmptyListSpec.scala
@@ -4,7 +4,7 @@ import monocle.MonocleSuite
 import monocle.law.discipline.IsoTests
 import monocle.law.discipline.function._
 
-import scalaz.NonEmptyList
+import scalaz.{IList, NonEmptyList}
 
 class NonEmptyListSpec extends MonocleSuite {
   checkAll("nelToAndOne", IsoTests(nelToOneAnd[Int]))
@@ -14,6 +14,6 @@ class NonEmptyListSpec extends MonocleSuite {
   checkAll("index NonEmptyList", IndexTests[NonEmptyList[Int], Int, Int])
   checkAll("filterIndex NonEmptyList", FilterIndexTests[NonEmptyList[Int], Int, Int])
   checkAll("reverse NonEmptyList", ReverseTests[NonEmptyList[Int]])
-  checkAll("cons1 NonEmptyList", Cons1Tests[NonEmptyList[Int], Int, List[Int]])
-  checkAll("snoc1 NonEmptyList", Snoc1Tests[NonEmptyList[Int], List[Int], Int])
+  checkAll("cons1 NonEmptyList", Cons1Tests[NonEmptyList[Int], Int, IList[Int]])
+  checkAll("snoc1 NonEmptyList", Snoc1Tests[NonEmptyList[Int], IList[Int], Int])
 }


### PR DESCRIPTION
I guess this is quite a controversial change. The idea is to move all typeclass instances in `core` from `monocle.std` to the corresponding typeclass companion object. This means users will be able to use most typeclass based optics using only `import monocle.function._`.

It is actually how an early version of monocle was done, I decided to move to the `std` package approach to be more consistent between modules (e.g. `generic` or `refined` module cannot define instance in companion object of typeclass) and to be more consistent with libraries like `scalaz`. However, I believe that most usage of our typeclasses concern either vanilla scala or scalaz types, so it makes sense to simplify this use case. 

As far as I remember, @NightRa was originally against the move to std module.
