### PR TITLE
extend peripheral modules

### DIFF
--- a/example/src/test/scala/monocle/state/ReaderExample.scala
+++ b/example/src/test/scala/monocle/state/ReaderExample.scala
@@ -1,0 +1,26 @@
+package monocle.state
+
+import monocle.{MonocleSuite, Getter}
+
+class ReaderExample extends MonocleSuite {
+
+  case class Person(name: String, age: Int)
+  val _age = Getter[Person, Int](_.age)
+  val p = Person("John", 30)
+
+  test("ask"){
+    val getAge = for {
+      i <- _age ask
+    } yield i
+
+    getAge.run(p) shouldEqual (30)
+  }
+
+  test("asks"){
+    val getDoubleAge = for {
+      i <- _age asks (_ * 2)
+    } yield i
+
+    getDoubleAge.run(p) shouldEqual (60)
+  }
+}

--- a/example/src/test/scala/monocle/state/StateExample.scala
+++ b/example/src/test/scala/monocle/state/StateExample.scala
@@ -1,6 +1,6 @@
 package monocle.state
 
-import monocle.{MonocleSuite, Optional}
+import monocle.{MonocleSuite, Optional, Setter, Getter}
 import monocle.macros.GenLens
 
 class StateExample extends MonocleSuite {
@@ -8,6 +8,22 @@ class StateExample extends MonocleSuite {
   case class Person(name: String, age: Int)
   val _age = GenLens[Person](_.age)
   val p = Person("John", 30)
+
+  test("extract"){
+    val getAge = for {
+      i <- _age extract
+    } yield i
+
+    getAge.run(p) shouldEqual ((Person("John", 30), 30))
+  }
+
+  test("extracts"){
+    val getDoubleAge = for {
+      i <- _age extracts (_ * 2)
+    } yield i
+
+    getDoubleAge.run(p) shouldEqual ((Person("John", 30), 60))
+  }
 
   test("mod"){
     val increment = for {
@@ -23,6 +39,12 @@ class StateExample extends MonocleSuite {
     } yield i
 
     increment.run(p) shouldEqual ((Person("John", 31), 30))
+  }
+
+  test("mod_"){
+    val increment = _age mod_ (_ + 1)
+
+    increment.run(p) shouldEqual ((Person("John", 31), ()))
   }
 
   test("assign"){
@@ -41,8 +63,60 @@ class StateExample extends MonocleSuite {
     set20.run(p) shouldEqual ((Person("John", 20), 30))
   }
 
+  test("assign_"){
+    val set20 = _age assign_ 20
+
+    set20.run(p) shouldEqual ((Person("John", 20), ()))
+  }
+
   val _oldAge = Optional[Person, Int](p => if (p.age > 50) Some(p.age) else None){ a => _.copy(age = a) }
   val _coolGuy = Optional[Person, String](p => if (p.name.startsWith("C")) Some(p.name) else None){ n => _.copy(name = n) }
+
+  test("extract for Optional (predicate is false)"){
+    val youngPerson = Person("John", 30)
+    val update = _oldAge extract
+
+    update.run(youngPerson) shouldEqual ((Person("John", 30), None))
+  }
+
+  test("extract for Optional (predicate is true)"){
+    val oldPerson = Person("John", 100)
+    val update = _oldAge extract
+
+    update.run(oldPerson) shouldEqual ((Person("John", 100), Some(100)))
+  }
+
+  test("extracts for Optional (predicate is false)"){
+    val youngPerson = Person("John", 30)
+    val update = _oldAge extracts (_ * 2)
+
+    update.run(youngPerson) shouldEqual ((Person("John", 30), None))
+  }
+
+  test("extracts for Optional (predicate is true)"){
+    val oldPerson = Person("John", 100)
+    val update = _oldAge extracts (_ * 2)
+
+    update.run(oldPerson) shouldEqual ((Person("John", 100), Some(200)))
+  }
+
+  test("mod for Optional (predicate is false)"){
+    val youngPerson = Person("John", 30)
+    val update = for {
+      i <- _oldAge mod (_ + 1)
+    } yield i
+
+    update.run(youngPerson) shouldEqual ((Person("John", 30), None))
+  }
+
+  test("mod for Optional (predicate is true)"){
+    val oldPerson = Person("John", 100)
+    val update = for {
+      i <- _oldAge mod (_ + 1)
+    } yield i
+
+    update.run(oldPerson) shouldEqual ((Person("John", 101), Some(101)))
+  }
 
   test("modo for Optional (predicate is false)"){
     val youngPerson = Person("John", 30)
@@ -82,4 +156,95 @@ class StateExample extends MonocleSuite {
     update.run(oldCoolPerson) shouldEqual ((Person("chris", 30), Some("Chris")))
   }
 
+  test("mod_ for Optional (predicate is false)"){
+    val youngPerson = Person("John", 30)
+    val update = _oldAge mod_ (_ + 1)
+
+    update.run(youngPerson) shouldEqual ((Person("John", 30), ()))
+  }
+
+  test("mod_ for Optional (predicate is true)"){
+    val oldPerson = Person("John", 100)
+    val update = _oldAge mod_ (_ + 1)
+
+    update.run(oldPerson) shouldEqual ((Person("John", 101), ()))
+  }
+
+  test("assign for Optional (predicate is true)"){
+    val oldPerson = Person("John", 100)
+    val update = for {
+      i <- _oldAge assign 30
+    } yield i
+
+    update.run(oldPerson) shouldEqual ((Person("John", 30), Some(30)))
+  }
+
+  test("assign for Optional (predicate is false)"){
+    val youngPerson = Person("John", 30)
+    val update = for {
+      i <- _oldAge assign 100
+    } yield i
+
+    update.run(youngPerson) shouldEqual ((Person("John", 30), None))
+  }
+
+  test("assigno for Optional (predicate is true)"){
+    val oldPerson = Person("John", 100)
+    val update = for {
+      i <- _oldAge assigno 30
+    } yield i
+
+    update.run(oldPerson) shouldEqual ((Person("John", 30), Some(100)))
+  }
+
+  test("assigno for Optional (predicate is false)"){
+    val youngPerson = Person("John", 30)
+    val update = for {
+      i <- _oldAge assigno 100
+    } yield i
+
+    update.run(youngPerson) shouldEqual ((Person("John", 30), None))
+  }
+
+  test("assign_ for Optional (predicate is true)"){
+    val oldPerson = Person("John", 100)
+    val update = _oldAge assign_ 30
+
+    update.run(oldPerson) shouldEqual ((Person("John", 30),()))
+  }
+
+  test("assign_ for Optional (predicate is false)"){
+    val youngPerson = Person("John", 30)
+    val update = _oldAge assign_ 100
+
+    update.run(youngPerson) shouldEqual ((Person("John", 30), ()))
+  }
+
+  val _nameSet = Setter[Person, String](f => p => p.copy(name = f(p.name)))
+
+  test("mod_ for Setter"){
+    val toUpper = _nameSet mod_ (_.toUpperCase)
+
+    toUpper.run(p) shouldEqual ((Person("JOHN", 30), ()))
+  }
+
+  test("assign_ for Setter"){
+    val toUpper = _nameSet assign_ ("Juan")
+
+    toUpper.run(p) shouldEqual ((Person("Juan", 30), ()))
+  }
+
+  val _nameGet = Getter[Person, String](_.name)
+
+  test("extract for Getter"){
+    val name = _nameGet extract
+
+    name.run(p) shouldEqual ((Person("John", 30), "John"))
+  }
+
+  test("extracts for Getter"){
+    val upper = _nameGet extracts (_.toUpperCase)
+
+    upper.run(p) shouldEqual ((Person("John", 30), "JOHN"))
+  }
 }

--- a/state/shared/src/main/scala/monocle/state/All.scala
+++ b/state/shared/src/main/scala/monocle/state/All.scala
@@ -1,3 +1,7 @@
 package monocle.state
 
-object all extends StateLensSyntax with StateOptionalSyntax
+object all extends StateLensSyntax
+  with StateOptionalSyntax
+  with StateGetterSyntax
+  with StateSetterSyntax
+  with ReaderGetterSyntax

--- a/state/shared/src/main/scala/monocle/state/ReaderGetterSyntax.scala
+++ b/state/shared/src/main/scala/monocle/state/ReaderGetterSyntax.scala
@@ -1,0 +1,28 @@
+package monocle.state
+
+import monocle.Getter
+
+import scalaz.{Reader}
+
+trait ReaderGetterSyntax {
+  implicit def toReaderGetterOps[S, A](getter: Getter[S, A]): ReaderGetterOps[S, A] =
+    new ReaderGetterOps[S, A](getter)
+}
+
+final class ReaderGetterOps[S, A](getter: Getter[S, A]) {
+  /** transforms a Getter into a Reader */
+  def toReader: Reader[S, A] =
+    Reader(getter.get)
+
+  /** alias for toReader */
+  def rd: Reader[S, A] =
+    toReader
+
+  /** extracts the value viewed through the getter */
+  def ask: Reader[S, A] =
+    toReader
+
+  /** extracts the value viewed through the getter and applies `f` over it */
+  def asks[B](f: A => B): Reader[S, B] =
+    ask.map(f)
+}

--- a/state/shared/src/main/scala/monocle/state/StateGetterSyntax.scala
+++ b/state/shared/src/main/scala/monocle/state/StateGetterSyntax.scala
@@ -1,0 +1,28 @@
+package monocle.state
+
+import monocle.Getter
+
+import scalaz.{IndexedState, State}
+
+trait StateGetterSyntax {
+  implicit def toStateGetterOps[S, A](getter: Getter[S, A]): StateGetterOps[S, A] =
+    new StateGetterOps[S, A](getter)
+}
+
+final class StateGetterOps[S, A](getter: Getter[S, A]) {
+  /** transforms a Getter into a State */
+  def toState: State[S, A] =
+    State(s => (s, getter.get(s)))
+
+  /** alias for toState */
+  def st: State[S, A] =
+    toState
+
+  /** extracts the value viewed through the getter */
+  def extract: State[S, A] =
+    toState
+
+  /** extracts the value viewed through the getter and applies `f` over it */
+  def extracts[B](f: A => B): State[S, B] =
+    extract.map(f)
+}

--- a/state/shared/src/main/scala/monocle/state/StateOptionalSyntax.scala
+++ b/state/shared/src/main/scala/monocle/state/StateOptionalSyntax.scala
@@ -3,6 +3,7 @@ package monocle.state
 import monocle.POptional
 
 import scalaz.{IndexedState, State}
+import scalaz.syntax.functor._
 
 trait StateOptionalSyntax {
   implicit def toStateOptionalOps[S, T, A, B](optional: POptional[S, T, A, B]): StateOptionalOps[S, T, A, B] =
@@ -18,11 +19,35 @@ final class StateOptionalOps[S, T, A, B](optional: POptional[S, T, A, B]) {
   def st: State[S, Option[A]] =
     toState
 
+    /** extracts the value viewed through the optional */
+  def extract: State[S, Option[A]] =
+    toState
+
+  /** extracts the value viewed through the optional and applies `f` over it */
+  def extracts[B](f: A => B): State[S, Option[B]] =
+    extract.map(_.map(f))
+
+  /** modify the value viewed through the Optional and return its *new* value, if there is one */
+  def mod(f: A => B): IndexedState[S, T, Option[B]] =
+    modo(f).map(_.map(f))
+
   /** modify the value viewed through the Optional and return its *old* value, if there was one */
   def modo(f: A => B): IndexedState[S, T, Option[A]] =
     IndexedState(s => (optional.modify(f)(s), optional.getOption(s)))
 
-  /** set the value viewed through the Optional and return its *old* value, if there was one */
-  def assigno(b: B): IndexedState[S, T, Option[A]] = modo(_ => b)
+  /** modify the value viewed through the Optional and ignores both values */
+  def mod_(f: A => B): IndexedState[S, T, Unit] =
+    IndexedState(s => (optional.modify(f)(s), ()))
 
+  /** set the value viewed through the Optional and returns its *new* value */
+  def assign(b: B): IndexedState[S, T, Option[B]] =
+    mod(_ => b)
+
+  /** set the value viewed through the Optional and return its *old* value, if there was one */
+  def assigno(b: B): IndexedState[S, T, Option[A]] =
+    modo(_ => b)
+
+  /** set the value viewed through the Optional and ignores both values */
+  def assign_(b: B): IndexedState[S, T, Unit] =
+    mod_(_ => b)
 }

--- a/state/shared/src/main/scala/monocle/state/StateSetterSyntax.scala
+++ b/state/shared/src/main/scala/monocle/state/StateSetterSyntax.scala
@@ -1,0 +1,20 @@
+package monocle.state
+
+import monocle.PSetter
+
+import scalaz.{IndexedState, State}
+
+trait StateSetterSyntax {
+  implicit def toStateSetterOps[S, T, A, B](setter: PSetter[S, T, A, B]): StateSetterOps[S, T, A, B] =
+    new StateSetterOps[S, T, A, B](setter)
+}
+
+final class StateSetterOps[S, T, A, B](setter: PSetter[S, T, A, B]) {
+  /** modify the value referenced through the setter */
+  def mod_(f: A => B): IndexedState[S, T, Unit] =
+    IndexedState(s => (setter.modify(f)(s), ()))
+
+  /** set the value referenced through the setter */
+  def assign_(b: B): IndexedState[S, T, Unit] =
+    mod_(_ => b)
+}

--- a/test/shared/src/test/scala/monocle/MonocleSuite.scala
+++ b/test/shared/src/test/scala/monocle/MonocleSuite.scala
@@ -3,7 +3,7 @@ package monocle
 import monocle.function.GenericOptics
 import monocle.generic.GenericInstances
 import monocle.refined.RefinedInstances
-import monocle.state.{StateLensSyntax, StateOptionalSyntax}
+import monocle.state._
 import monocle.std.StdInstances
 import monocle.syntax.Syntaxes
 import org.scalatest.{FunSuite, Matchers}
@@ -20,3 +20,6 @@ trait MonocleSuite extends FunSuite
                       with Syntaxes
                       with StateLensSyntax
                       with StateOptionalSyntax
+                      with StateGetterSyntax
+                      with StateSetterSyntax
+                      with ReaderGetterSyntax


### PR DESCRIPTION
This PR contains some changes in the peripheral modules:

* It includes new methods (`extract`, `extracts`, `assign_` and `mod_`) for the existing lens and optional representatives in the state module.
* It adds new representatives in the state module, such as `Getter` and `Setter`.
* It adds a new *reader* module, which includes a `Getter` representative as example.

In general, these ideas have emerged while writing a blog post, ["Lens, State Is Your Father"](https://blog.hablapps.com/2016/11/10/lens-state-is-your-father/), where they are described in detail.