### PR TITLE
Add .zip to Getter

### DIFF
--- a/core/shared/src/main/scala/monocle/Getter.scala
+++ b/core/shared/src/main/scala/monocle/Getter.scala
@@ -1,6 +1,6 @@
 package monocle
 
-import scalaz.{Arrow, Choice, Monoid, \/}
+import scalaz.{Arrow, Choice, Monoid, Zip, \/}
 
 /**
  * A [[Getter]] can be seen as a glorified get method between
@@ -32,6 +32,9 @@ abstract class Getter[S, A] extends Serializable { self =>
   /** pair two disjoint [[Getter]] */
   @inline final def split[S1, A1](other: Getter[S1, A1]): Getter[(S, S1), (A, A1)] =
     Getter[(S, S1), (A, A1)]{case (s, s1) => (self.get(s), other.get(s1))}
+
+  @inline final def zip[A1](other: Getter[S, A1]): Getter[S, (A, A1)] =
+    Getter[S, (A, A1)](s => (self.get(s), other.get(s)))
 
   @inline final def first[B]: Getter[(S, B), (A, B)] =
     Getter[(S, B), (A, B)]{case (s, b) => (self.get(s), b)}
@@ -154,6 +157,10 @@ sealed abstract class GetterInstances extends GetterInstances0 {
 
     def compose[A, B, C](f: Getter[B, C], g: Getter[A, B]): Getter[A, C] =
       g composeGetter f
+  }
+
+  implicit def getterZip[S]: Zip[Getter[S, ?]] = new Zip[Getter[S, ?]] {
+    override def zip[A, B](a: => Getter[S, A], b: => Getter[S, B]) = a zip b
   }
 }
 

--- a/test/shared/src/test/scala/monocle/GetterSpec.scala
+++ b/test/shared/src/test/scala/monocle/GetterSpec.scala
@@ -37,6 +37,12 @@ class GetterSpec extends MonocleSuite {
     Arrow[Getter].arr((_: Int) * 2).get(4) shouldEqual 8
   }
 
+  test("Getter has a Zip instance") {
+    val length = Getter[String, Int](_.length)
+    val upper = Getter[String, String](_.toUpperCase)
+    Zip[Getter[String, ?]].zip(length, upper).get("helloworld") shouldEqual((10, "HELLOWORLD"))
+  }
+
   test("get") {
     i.get(Bar(5)) shouldEqual 5
   }


### PR DESCRIPTION
As per [Gitter](https://gitter.im/julien-truffaut/Monocle?at=5853cf11c895451b75e2a6f9) this is `.zip` for Getter.  

@julien-truffaut I looked at `.zip` for `Fold` as well, but I must admit that the implementation wasn't immediately obvious to me, and I didn't have the time to think about it yet.  I'll get back to it when I've got more time.  Would appreciate pointers in the right direction :blush:
