### PR TITLE
New `Possible` typeclass that defines a canonical Optional over a type

### DIFF
--- a/core/shared/src/main/scala/monocle/function/All.scala
+++ b/core/shared/src/main/scala/monocle/function/All.scala
@@ -18,6 +18,7 @@ trait GenericOptics
   with    FilterIndexFunctions
   with    IndexFunctions
   with    PlatedFunctions
+  with    PossibleFunctions
   with    ReverseFunctions
   with    SnocFunctions
   with    Snoc1Functions

--- a/core/shared/src/main/scala/monocle/function/Possible.scala
+++ b/core/shared/src/main/scala/monocle/function/Possible.scala
@@ -1,0 +1,59 @@
+package monocle.function
+
+import monocle.{Iso, Prism}
+import scalaz.{\/, Validation, Maybe}
+import scala.util.{Try, Success, Failure}
+
+/**
+ * Typeclass that defines a [[Prism]] from a monomorphic container `S` to a possible `A` value.
+ * @tparam S source of the [[Prism]]
+ * @tparam A target of the [[Prism]], `A` is supposed to be unique for a given `S`
+ */
+abstract class Possible[S, A] extends Serializable {
+  def possible: Prism[S, A]
+}
+
+trait PossibleFunctions {
+  def possible[S, A](implicit ev: Possible[S, A]): Prism[S, A] = ev.possible
+}
+
+object Possible extends PossibleFunctions {
+  /** lift an instance of [[Optional]] using an [[Iso]] */
+  def fromIso[S, A, B](iso: Iso[S, A])(implicit ev: Possible[A, B]): Possible[S, B] = new Possible[S, B] {
+    val possible: Prism[S, B] =
+      iso composePrism ev.possible
+  }
+
+  /************************************************************************************************/
+  /** Std instances                                                                               */
+  /************************************************************************************************/
+  implicit def optionPossible[A]: Possible[Option[A], A] = 
+    new Possible[Option[A], A] { 
+      def possible = monocle.std.option.some
+    }
+
+  implicit def eitherPossible[A,B]: Possible[Either[A,B], B] =
+    new Possible[Either[A,B], B] { 
+      def possible = monocle.std.either.stdRight
+    }
+
+  implicit def maybePossible[A,B]: Possible[Maybe[A], A] =
+    new Possible[Maybe[A], A] { 
+      def possible = monocle.std.maybe.just
+    }
+
+  implicit def disjunctionPossible[A,B]: Possible[A \/ B, B] =
+    new Possible[A \/ B, B] { 
+      def possible = monocle.std.disjunction.right
+    }
+
+  implicit def validationPossible[A,B]: Possible[Validation[A,B], B] =
+    new Possible[Validation[A,B], B] { 
+      def possible = monocle.std.validation.success
+    }
+
+  implicit def tryPossible[A]: Possible[Try[A], A] =
+    new Possible[Try[A], A] { 
+      def possible = monocle.std.utilTry.trySuccess
+    }
+}

--- a/core/shared/src/main/scala/monocle/std/All.scala
+++ b/core/shared/src/main/scala/monocle/std/All.scala
@@ -18,6 +18,7 @@ trait StdInstances
   with    OptionOptics
   with    StringOptics
   with    Tuple1Optics
+  with    TryOptics
   // Scalaz Instances
   with    CofreeOptics
   with    Either3Optics

--- a/core/shared/src/main/scala/monocle/std/Try.scala
+++ b/core/shared/src/main/scala/monocle/std/Try.scala
@@ -1,0 +1,27 @@
+package monocle.std
+
+import monocle.{Prism, PPrism}
+
+import scala.util.{Try, Success, Failure}
+
+import scalaz.{\/, -\/, \/-}
+
+object utilTry extends TryOptics
+
+trait TryOptics {
+
+  final def pTrySuccess[A, B]: PPrism[Try[A], Try[B], A, B] =
+    PPrism[Try[A], Try[B], A, B] {
+      case Success(a) => \/-(a) 
+      case Failure(e) => -\/(Failure(e)) 
+    }(Success.apply)
+
+  final def trySuccess[A]: Prism[Try[A], A] =
+    pTrySuccess[A, A]
+
+  final def tryFailure[A]: Prism[Try[A], Throwable] =
+    Prism[Try[A], Throwable] {
+      case Success(a) => None
+      case Failure(e) => Some(e)
+    }(Failure.apply)
+}

--- a/law/shared/src/main/scala/monocle/law/discipline/function/PossibleTests.scala
+++ b/law/shared/src/main/scala/monocle/law/discipline/function/PossibleTests.scala
@@ -1,0 +1,17 @@
+package monocle.law.discipline.function
+
+import monocle.function.Possible._
+import monocle.function._
+import monocle.law.discipline.PrismTests
+import org.scalacheck.Arbitrary
+import org.typelevel.discipline.Laws
+
+import scalaz.Equal
+
+
+object PossibleTests extends Laws {
+
+  def apply[S: Equal : Arbitrary, A: Equal : Arbitrary](implicit evPossible: Possible[S, A], arbAA: Arbitrary[A => A]): RuleSet =
+    new SimpleRuleSet("Possible", PrismTests(possible[S, A]).props: _*)
+
+}

--- a/test/shared/src/test/scala/monocle/function/PossibleSpec.scala
+++ b/test/shared/src/test/scala/monocle/function/PossibleSpec.scala
@@ -1,0 +1,22 @@
+package monocle.function
+
+import monocle.Iso
+import monocle.MonocleSuite
+import monocle.law.discipline.function.PossibleTests
+import Possible.optionPossible
+
+class PossibleSpec extends MonocleSuite {
+
+  implicit def optionEitherPossible[A]: Possible[Either[Unit,A], A] = 
+  Possible.fromIso(
+    Iso[Either[Unit,A], Option[A]] {
+      case Right(a) => Some(a)
+      case Left(_) => None 
+    } {
+      case Some(a) => Right(a) 
+      case None => Left(()) 
+    })
+
+  checkAll("fromIso", PossibleTests[Either[Unit,Int], Int])
+
+}

--- a/test/shared/src/test/scala/monocle/std/DisjunctionSpec.scala
+++ b/test/shared/src/test/scala/monocle/std/DisjunctionSpec.scala
@@ -2,6 +2,8 @@ package monocle.std
 
 import monocle.MonocleSuite
 import monocle.law.discipline.{IsoTests, PrismTests}
+import monocle.law.discipline.function.PossibleTests
+import scalaz.\/
 
 class DisjunctionSpec extends MonocleSuite {
   checkAll("disjunction left" , PrismTests(left[String, Int]))
@@ -9,4 +11,6 @@ class DisjunctionSpec extends MonocleSuite {
 
   checkAll("disjunction to Validation", IsoTests(disjunctionToValidation[String, Int]))
   checkAll("disjunction to Either"    , IsoTests(disjunctionToEither[String, Int]))
+
+  checkAll("possible disjunction", PossibleTests[Unit \/ Int, Int])
 }

--- a/test/shared/src/test/scala/monocle/std/EitherSpec.scala
+++ b/test/shared/src/test/scala/monocle/std/EitherSpec.scala
@@ -2,8 +2,10 @@ package monocle.std
 
 import monocle.MonocleSuite
 import monocle.law.discipline.PrismTests
+import monocle.law.discipline.function.PossibleTests
 
 class EitherSpec extends MonocleSuite {
   checkAll("either left" , PrismTests(stdLeft[String, Int]))
   checkAll("either right", PrismTests(stdRight[String, String]))
+  checkAll("possible Either", PossibleTests[Either[Unit, Int], Int])
 }

--- a/test/shared/src/test/scala/monocle/std/MaybeSpec.scala
+++ b/test/shared/src/test/scala/monocle/std/MaybeSpec.scala
@@ -1,7 +1,7 @@
 package monocle.std
 
 import monocle.MonocleSuite
-import monocle.law.discipline.function.{EachTests, EmptyTests}
+import monocle.law.discipline.function.{EachTests, PossibleTests, EmptyTests}
 import monocle.law.discipline.{IsoTests, PrismTests}
 
 import scalaz.Maybe
@@ -13,4 +13,5 @@ class MaybeSpec extends MonocleSuite {
 
   checkAll("each Maybe", EachTests[Maybe[Int], Int])
   checkAll("empty Maybe", EmptyTests[Maybe[Int]])
+  checkAll("possible Maybe", PossibleTests[Maybe[Int], Int])
 }

--- a/test/shared/src/test/scala/monocle/std/OptionSpec.scala
+++ b/test/shared/src/test/scala/monocle/std/OptionSpec.scala
@@ -2,7 +2,7 @@ package monocle.std
 
 import monocle.MonocleSuite
 import monocle.law.discipline.{PrismTests, IsoTests}
-import monocle.law.discipline.function.{EachTests, EmptyTests}
+import monocle.law.discipline.function.{EachTests, PossibleTests, EmptyTests}
 
 class OptionSpec extends MonocleSuite {
   checkAll("some", PrismTests(some[Int]))
@@ -11,5 +11,6 @@ class OptionSpec extends MonocleSuite {
   checkAll("pOptionToDisjunction", IsoTests(pOptionToDisjunction[Int, Int]))
 
   checkAll("each Option", EachTests[Option[Int], Int])
+  checkAll("possible Option", PossibleTests[Option[Int], Int])
   checkAll("empty Option",EmptyTests[Option[Int]])
 }

--- a/test/shared/src/test/scala/monocle/std/TrySpec.scala
+++ b/test/shared/src/test/scala/monocle/std/TrySpec.scala
@@ -1,0 +1,23 @@
+package monocle.std
+
+import monocle.MonocleSuite
+import monocle.law.discipline.{IsoTests, PrismTests}
+import monocle.law.discipline.function.PossibleTests
+
+import scala.util.Try
+
+import scalaz.Equal
+
+
+class TrySpec extends MonocleSuite {
+
+  private implicit def tryEqual[A]: Equal[Try[A]] = 
+    Equal.equalA[Try[A]]
+
+  private implicit def throwableEqual[A]: Equal[Throwable] = 
+    Equal.equalA[Throwable]
+    
+  checkAll("trySuccess", PrismTests(monocle.std.utilTry.trySuccess[Int]))
+  checkAll("tryFailure", PrismTests(monocle.std.utilTry.tryFailure[Int]))
+  checkAll("possible Try", PossibleTests[Try[Int], Int])
+}

--- a/test/shared/src/test/scala/monocle/std/ValidationSpec.scala
+++ b/test/shared/src/test/scala/monocle/std/ValidationSpec.scala
@@ -2,9 +2,12 @@ package monocle.std
 
 import monocle.MonocleSuite
 import monocle.law.discipline.{IsoTests, PrismTests}
+import monocle.law.discipline.function.PossibleTests
+import scalaz.Validation
 
 class ValidationSpec extends MonocleSuite {
   checkAll("Validation is isomorphic to Disjunction", IsoTests(monocle.std.validation.validationToDisjunction[String, Int]))
   checkAll("success", PrismTests(monocle.std.validation.success[String, Int]))
   checkAll("failure", PrismTests(monocle.std.validation.failure[String, Int]))
+  checkAll("possible Validation", PossibleTests[Validation[Unit, Int], Int])
 }


### PR DESCRIPTION
As discussed in #450.

The code is basically a facsimile of the `Each` code, with `Optional` instead of `Traversal`, and instances for `Option`, `Either`, `\/`, `Validation` and `Maybe`.  I've omitted support for `scala.util.Try`, which should probably have its own file in `std`, and would be better presented as a separate PR.

The property based test follows `Each` in using the `fromIso` method as a vehicle for hitching the concept to the `Optional` laws.  

I haven't added anything special for `possible.asTraversable == each`, because it concerns types that have both `Each` and `Possible` instances, which only `Maybe` currently satisfies, and possibly warrants further conversation.   

It would be technically correct to make `Possible` a subclass of `Each` (ie every `Possible` yields a `Traversal`, but not every `Each` yields an `Optional`), but Monocle has consistently avoided subclassing, and there is no reason to change policy here. We could, however, provide `Each` instances for each of the `Possible` instances, yielding `Traversal`s that obey the `Optional` laws.