### PR TITLE
Use refinedPrism to implement chars prisms

### DIFF
--- a/refined/shared/src/main/scala/monocle/refined/chars.scala
+++ b/refined/shared/src/main/scala/monocle/refined/chars.scala
@@ -1,19 +1,10 @@
 package monocle.refined
 
-import eu.timepit.refined.api.Refined
-import eu.timepit.refined.char.{LowerCase, UpperCase}
 import monocle._
-
 
 object chars extends CharsInstances
 
 trait CharsInstances {
-  val lowerCase: Prism[Char, LowerCaseChar] = toCase[LowerCase](c => c.isLower)
-  val upperCase: Prism[Char, UpperCaseChar] = toCase[UpperCase](c => c.isUpper)
-
-  private def toCase[P](p: Char => Boolean): Prism[Char, Refined[Char, P]] =
-    Prism.partial[Char, Refined[Char, P]] {
-      case char if p(char) => Refined.unsafeApply(char)
-    }{_.value}
+  val lowerCase: Prism[Char, LowerCaseChar] = refinedPrism
+  val upperCase: Prism[Char, UpperCaseChar] = refinedPrism
 }
-

--- a/refined/shared/src/main/scala/monocle/refined/package.scala
+++ b/refined/shared/src/main/scala/monocle/refined/package.scala
@@ -1,7 +1,7 @@
 package monocle
 
 import eu.timepit.refined._
-import eu.timepit.refined.api.Refined
+import eu.timepit.refined.api.{Refined, Validate}
 import eu.timepit.refined.char.{LowerCase, UpperCase}
 import eu.timepit.refined.string.{EndsWith, StartsWith}
 import eu.timepit.refined.numeric.Interval
@@ -20,4 +20,10 @@ package object refined {
   type StartsWithString[T <: String] = String Refined StartsWith[T]
   type EndsWithString[T <: String] = String Refined EndsWith[T]
 
+  private[refined] def refinedPrism[T, P](implicit v: Validate[T, P]): Prism[T, T Refined P] =
+    Prism.partial[T, T Refined P] {
+      case t if v.isValid(t) => Refined.unsafeApply(t)
+    } {
+      _.value
+    }
 }

--- a/refined/shared/src/main/scala/monocle/refined/strings.scala
+++ b/refined/shared/src/main/scala/monocle/refined/strings.scala
@@ -1,6 +1,6 @@
 package monocle.refined
 
-import eu.timepit.refined.api.{Refined, Validate}
+import eu.timepit.refined.api.Validate
 import eu.timepit.refined.string.{EndsWith, StartsWith}
 import monocle._
 
@@ -9,16 +9,8 @@ object strings extends StringsInstances
 trait StringsInstances {
 
   def startsWith(prefix: String)(implicit v: Validate[String, StartsWith[prefix.type]]): Prism[String, StartsWithString[prefix.type]] =
-    refinedPrism[String, StartsWith[prefix.type]](prefix)
+    refinedPrism
 
   def endsWith(suffix: String)(implicit v: Validate[String, EndsWith[suffix.type]]): Prism[String, EndsWithString[suffix.type]] =
-    refinedPrism[String, EndsWith[suffix.type]](suffix)
-
-  private def refinedPrism[T, P](t: T)(implicit v: Validate[T, P]): Prism[T, T Refined P] = {
-    Prism.partial[T, Refined[T, P]] {
-      case tt if v.isValid(tt) => Refined.unsafeApply[T, P](tt)
-    } {
-      _.value
-    }
-  }
+    refinedPrism
 }


### PR DESCRIPTION
This uses `refinedPrism` (which was added in #483) to implement
`chars.lowerCase` and `chars.upperCase`.