### PR TITLE
Adds coalgebroid-based constructors for Lens and Traversal

### DIFF
--- a/core/shared/src/main/scala/monocle/Lens.scala
+++ b/core/shared/src/main/scala/monocle/Lens.scala
@@ -1,7 +1,7 @@
 package monocle
 
 import monocle.function.fields.{first, second}
-import scalaz.{Applicative, Choice, ComonadStore, Functor, Monoid, Split, Unzip, \/}
+import scalaz.{Applicative, Choice, IndexedStore, Functor, Monoid, Split, Unzip, \/}
 
 /**
  * A [[PLens]] can be seen as a pair of functions:
@@ -224,6 +224,12 @@ object PLens extends LensInstances {
     )(t => _.bimap(_ => t, _ => t))
 
   /**
+   * create a [[PLens]] from a context (indexed store) coalgebra.
+   */
+  def contextCoalg[S, T, A, B](f: S => IndexedStore[A, B, T]): PLens[S, T, A, B] =
+    PLens[S, T, A, B](s => f(s).pos)(b => s => f(s).peek(b))
+
+  /**
    * create a [[PLens]] using a pair of functions: one to get the target, one to set the target.
    * @see macro module for methods generating [[PLens]] with less boiler plate
    */
@@ -250,10 +256,6 @@ object Lens {
 
   def codiagonal[S]: Lens[S \/ S, S] =
     PLens.codiagonal
-
-  /** creates a [[Lens]] from a Store comonad coalgebra */
-  def storeFCoalg[F[_], S, A](f: S => F[S])(implicit CS: ComonadStore[F, A]): Lens[S, A] =
-    Lens[S, A](s => CS.pos(f(s)))(a => s => CS.peek(a, f(s)))
 
   /** alias for [[PLens]] apply with a monomorphic set function */
   def apply[S, A](get: S => A)(set: A => S => S): Lens[S, A] =

--- a/core/shared/src/main/scala/monocle/Lens.scala
+++ b/core/shared/src/main/scala/monocle/Lens.scala
@@ -1,7 +1,7 @@
 package monocle
 
 import monocle.function.fields.{first, second}
-import scalaz.{Applicative, Choice, Functor, Monoid, Split, Unzip, \/}
+import scalaz.{Applicative, Choice, ComonadStore, Functor, Monoid, Split, Unzip, \/}
 
 /**
  * A [[PLens]] can be seen as a pair of functions:
@@ -250,6 +250,10 @@ object Lens {
 
   def codiagonal[S]: Lens[S \/ S, S] =
     PLens.codiagonal
+
+  /** creates a [[Lens]] from a Store comonad coalgebra */
+  def storeFCoalg[F[_], S, A](f: S => F[S])(implicit CS: ComonadStore[F, A]): Lens[S, A] =
+    Lens[S, A](s => CS.pos(f(s)))(a => s => CS.peek(a, f(s)))
 
   /** alias for [[PLens]] apply with a monomorphic set function */
   def apply[S, A](get: S => A)(set: A => S => S): Lens[S, A] =

--- a/core/shared/src/main/scala/monocle/Traversal.scala
+++ b/core/shared/src/main/scala/monocle/Traversal.scala
@@ -229,7 +229,9 @@ object PTraversal extends TraversalInstances {
   def apply[S, T, A, B](f: S => FreeAp[IndexedStore[A, B, ?], T]) =
     new PTraversal[S, T, A, B] {
       def modifyF[F[_]: Applicative](g: A => F[B])(s: S): F[T] =
-        f(s).foldMap(λ[IndexedStore[A, B, ?] ~> F](is => g(is.pos).map(is.set)))
+        f(s).foldMap(new (IndexedStore[A, B, ?] ~> F) {
+          def apply[X](is: IndexedStore[A, B, X]) = g(is.pos).map(is.set)
+        })
     }
 }
 

--- a/core/shared/src/main/scala/monocle/Traversal.scala
+++ b/core/shared/src/main/scala/monocle/Traversal.scala
@@ -5,10 +5,11 @@ import scalaz.Id.Id
 import scalaz.std.anyVal._
 import scalaz.std.list._
 import scalaz.std.option._
+import scalaz.syntax.functor._
 import scalaz.syntax.std.boolean._
 import scalaz.syntax.std.option._
 import scalaz.syntax.tag._
-import scalaz.{Applicative, Choice, Const, Functor, Monoid, Traverse, Unzip, \/}
+import scalaz.{Applicative, Choice, Const, IndexedStore, FreeAp, Functor, Monoid, Traverse, Unzip, \/, ~>}
 
 /**
  * A [[PTraversal]] can be seen as a [[POptional]] generalised to 0 to n targets
@@ -225,6 +226,11 @@ object PTraversal extends TraversalInstances {
         Applicative[F].apply6(f(get1(s)), f(get2(s)), f(get3(s)), f(get4(s)), f(get5(s)), f(get6(s)))(_set(_, _, _, _, _, _, s))
     }
 
+  def apply[S, T, A, B](f: S => FreeAp[IndexedStore[A, B, ?], T]) =
+    new PTraversal[S, T, A, B] {
+      def modifyF[F[_]: Applicative](g: A => F[B])(s: S): F[T] =
+        f(s).foldMap(λ[IndexedStore[A, B, ?] ~> F](is => g(is.pos).map(is.set)))
+    }
 }
 
 object Traversal {

--- a/core/shared/src/main/scala/monocle/syntax/All.scala
+++ b/core/shared/src/main/scala/monocle/syntax/All.scala
@@ -2,4 +2,4 @@ package monocle.syntax
 
 object all extends Syntaxes
 
-trait Syntaxes extends ApplySyntax
+trait Syntaxes extends ApplySyntax with TraversalSyntax

--- a/core/shared/src/main/scala/monocle/syntax/Traversal.scala
+++ b/core/shared/src/main/scala/monocle/syntax/Traversal.scala
@@ -1,0 +1,112 @@
+package monocle.syntax
+
+import scalaz.{IndexedStore, FreeAp}
+
+object traversal extends TraversalSyntax
+
+trait TraversalSyntax {
+  implicit def toTraversalBuilder[A, B, T](a: A): TraversalBuilder[A, B, T] =
+    new TraversalBuilder[A, B, T] { val a1 = a }
+}
+
+trait TraversalBuilder[A, B, T] {
+  val a1: A
+
+  def apply(f: B => T) =
+    ap(a1, pt(f))
+
+  def ~(_a2: A) = new TraversalBuilder2 { val a2 = _a2 }
+
+  trait TraversalBuilder2 {
+    val a2: A
+
+    def apply(f: (B, B) => T) =
+      ap(a2, ap(a1, pt(f.curried)))
+
+    def ~(_a3: A) = new TraversalBuilder3 { val a3 = _a3 }
+
+    trait TraversalBuilder3 {
+      val a3: A
+
+      def apply(f: (B, B, B) => T) =
+        ap(a3, ap(a2, ap(a1, pt(f.curried))))
+
+      def ~(_a4: A) = new TraversalBuilder4 { val a4 = _a4 }
+
+      trait TraversalBuilder4 {
+        val a4: A
+
+        def apply(f: (B, B, B, B) => T) =
+          ap(a4, ap(a3, ap(a2, ap(a1, pt(f.curried)))))
+
+        def ~(_a5: A) = new TraversalBuilder5 { val a5 = _a5 }
+
+        trait TraversalBuilder5 {
+          val a5: A
+
+          def apply(f: (B, B, B, B, B) => T) =
+            ap(a5, ap(a4, ap(a3, ap(a2, ap(a1, pt(f.curried))))))
+
+          def ~(_a6: A) = new TraversalBuilder6 { val a6 = _a6 }
+
+          trait TraversalBuilder6 {
+            val a6: A
+
+            def apply(f: (B, B, B, B, B, B) => T) =
+              ap(a6, ap(a5, ap(a4, ap(a3, ap(a2, ap(a1, pt(f.curried)))))))
+
+            def ~(_a7: A) = new TraversalBuilder7 { val a7 = _a7 }
+
+            trait TraversalBuilder7 {
+              val a7: A
+
+              def apply(f: (B, B, B, B, B, B, B) => T) =
+                ap(a7, ap(a6, ap(a5, ap(a4, ap(a3, ap(a2, ap(a1, pt(f.curried))))))))
+
+              def ~(_a8: A) = new TraversalBuilder8 { val a8 = _a8 }
+
+              trait TraversalBuilder8 {
+                val a8: A
+
+                def apply(f: (B, B, B, B, B, B, B, B) => T) =
+                  ap(a8, ap(a7, ap(a6, ap(a5, ap(a4, ap(a3, ap(a2, ap(a1, pt(f.curried)))))))))
+
+                def ~(_a9: A) = new TraversalBuilder9 { val a9 = _a9 }
+
+                trait TraversalBuilder9 {
+                  val a9: A
+
+                  def apply(f: (B, B, B, B, B, B, B, B, B) => T) =
+                    ap(a9, ap(a8, ap(a7, ap(a6, ap(a5, ap(a4, ap(a3, ap(a2, ap(a1, pt(f.curried))))))))))
+
+                  def ~(_a10: A) = new TraversalBuilder10 { val a10 = _a10 }
+
+                  trait TraversalBuilder10 {
+                    val a10: A
+
+                    def apply(f: (B, B, B, B, B, B, B, B, B, B) => T) =
+                      ap(a10, ap(a9, ap(a8, ap(a7, ap(a6, ap(a5, ap(a4, ap(a3, ap(a2, ap(a1, pt(f.curried)))))))))))
+
+                    def ~(_a11: A) = new TraversalBuilder11 { val a11 = _a11 }
+
+                    trait TraversalBuilder11 {
+                      val a11: A
+
+                      def apply(f: (B, B, B, B, B, B, B, B, B, B, B) => T) =
+                        ap(a11, ap(a10, ap(a9, ap(a8, ap(a7, ap(a6, ap(a5, ap(a4, ap(a3, ap(a2, ap(a1, pt(f.curried))))))))))))
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private def pt[X](x: X) = FreeAp.point[IndexedStore[A, B, ?], X](x)
+
+  private def ap[X](h: A, x: => FreeAp[IndexedStore[A, B, ?], B => X]) =
+    FreeAp[IndexedStore[A, B, ?], B, X](IndexedStore(identity, h), x)
+}

--- a/test/shared/src/test/scala/monocle/LensSpec.scala
+++ b/test/shared/src/test/scala/monocle/LensSpec.scala
@@ -26,9 +26,9 @@ class LensSpec extends MonocleSuite {
 
   val s = Lens[Example, String](_.s)(s => ex => ex.copy(s = s))
   val p = Lens[Example, Point](_.p)(p => ex => ex.copy(p = p))
-
-  implicit def ev = IndexedStoreT.storeTComonadStore[Id.Id, String]
-  val t = Lens.storeFCoalg[Store[String, ?], Example, String](ex => Store(s => ex.copy(s = s), ex.s))
+  val t = PLens.contextCoalg[Example, Example, String, String] { ex =>
+    Store(s => ex.copy(s = s), ex.s)
+  }
 
   val x = Lens[Point, Int](_.x)(x => p => p.copy(x = x))
   val y = Lens[Point, Int](_.y)(y => p => p.copy(y = y))

--- a/test/shared/src/test/scala/monocle/LensSpec.scala
+++ b/test/shared/src/test/scala/monocle/LensSpec.scala
@@ -27,6 +27,9 @@ class LensSpec extends MonocleSuite {
   val s = Lens[Example, String](_.s)(s => ex => ex.copy(s = s))
   val p = Lens[Example, Point](_.p)(p => ex => ex.copy(p = p))
 
+  implicit def ev = IndexedStoreT.storeTComonadStore[Id.Id, String]
+  val t = Lens.storeFCoalg[Store[String, ?], Example, String](ex => Store(s => ex.copy(s = s), ex.s))
+
   val x = Lens[Point, Int](_.x)(x => p => p.copy(x = x))
   val y = Lens[Point, Int](_.y)(y => p => p.copy(y = y))
   val xy = Lens[Point, (Int, Int)](p => (p.x, p.y))(xy => p => p.copy(x = xy._1, y = xy._2))
@@ -40,6 +43,7 @@ class LensSpec extends MonocleSuite {
   implicit val exampleEq = Equal.equalA[Example]
 
   checkAll("apply Lens", LensTests(s))
+  checkAll("Store-coalgebra Lens", LensTests(t))
   checkAll("GenLens", LensTests(GenLens[Example](_.s)))
   checkAll("GenLens chain", LensTests(GenLens[Example](_.p.x)))
   checkAll("Lenses",  LensTests(Example.s))
@@ -96,5 +100,5 @@ class LensSpec extends MonocleSuite {
   test("modify") {
     x.modify(_ + 1)(Point(9, 2)) shouldEqual Point(10, 2)
   }
-  
+
 }

--- a/test/shared/src/test/scala/monocle/TraversalSpec.scala
+++ b/test/shared/src/test/scala/monocle/TraversalSpec.scala
@@ -5,7 +5,7 @@ import monocle.macros.GenLens
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary.arbitrary
 
-import scalaz.{-\/, Category, Choice, Compose, Equal, Unzip}
+import scalaz.{-\/, Category, Choice, Compose, Equal, FreeAp, IndexedStore, Unzip}
 import scalaz.std.string._
 import scalaz.std.list._
 
@@ -47,6 +47,13 @@ class TraversalSpec extends MonocleSuite {
   // the 7-lenses Traversal generated using applyN
   val traversalN: Traversal[ManyPropObject, Int] = Traversal.applyN(l1,l2,l3,l4,l5,l6,l7)
 
+  // the Traversal generated using PTraversal.apply (no lenses involved)
+  val ptraversalN: Traversal[ManyPropObject, Int] = PTraversal { obj =>
+    (obj.p1 ~ obj.p2 ~ obj.p4 ~ obj.p5 ~ obj.p6 ~ obj.p7 ~ obj.p8) {
+      ManyPropObject(_, _, obj.p3, _, _, _, _, _)
+    }
+  }
+
   // the stub for generating random test objects
   implicit val manyPropObjectGen: Arbitrary[ManyPropObject] = Arbitrary(for {
     p1 <- arbitrary[Int]
@@ -63,7 +70,8 @@ class TraversalSpec extends MonocleSuite {
 
   checkAll("apply2 Traversal", TraversalTests(coordinates))
   checkAll("applyN Traversal", TraversalTests(traversalN))
-  checkAll("fromTraverse Traversal" , TraversalTests(eachLi))
+  checkAll("applyN PTraversal", TraversalTests(ptraversalN))
+  checkAll("fromTraverse Traversal", TraversalTests(eachLi))
 
   checkAll("traversal.asSetter", SetterTests(coordinates.asSetter))
 

--- a/test/shared/src/test/scala/monocle/TraversalSpec.scala
+++ b/test/shared/src/test/scala/monocle/TraversalSpec.scala
@@ -49,7 +49,7 @@ class TraversalSpec extends MonocleSuite {
 
   // the Traversal generated using PTraversal.apply (no lenses involved)
   val ptraversalN: Traversal[ManyPropObject, Int] = PTraversal { obj =>
-    (obj.p1 ~ obj.p2 ~ obj.p4 ~ obj.p5 ~ obj.p6 ~ obj.p7 ~ obj.p8) {
+    (toTraversalBuilder(obj.p1) ~ obj.p2 ~ obj.p4 ~ obj.p5 ~ obj.p6 ~ obj.p7 ~ obj.p8) {
       ManyPropObject(_, _, obj.p3, _, _, _, _, _)
     }
   }


### PR DESCRIPTION
This includes an alternative constructor for lenses based on `Store` coalgebras. In fact, this constructor is even more generic, since it uses the `StoreComonad` typeclass, where `pos` and `peek` can be found.

(*) Similar constructors could be included for `PLens` (`S => IndexedStore[A, B, T]`), `Traversal` (`S => FreeAp[Store[A, ?], S]`) and `PTraversal` (`S => FreeAp[IndexedStore[A, B, T]]`).