### PR TITLE
support Scala Native

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,3 +44,17 @@ install:
   - gem install jekyll -v 3.2.1
 after_success:
 - '[[ $TRAVIS_BRANCH == "master" && "${TRAVIS_PULL_REQUEST}" == "false" ]] && { sbt +publish ghpagesPushSite; };'
+matrix:
+  include:
+  - scala: 2.11.8
+    jdk: oraclejdk8
+    sudo: required
+    before_install:
+    - wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
+    - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+    - sudo add-apt-repository -y "deb http://apt.llvm.org/precise/ llvm-toolchain-precise main"
+    - sudo add-apt-repository -y "deb http://apt.llvm.org/precise/ llvm-toolchain-precise-3.7 main"
+    - sudo apt-get update -qq
+    - sudo apt-get install -y libgc-dev clang++-3.7 llvm-3.7 llvm-3.7-dev llvm-3.7-runtime llvm-3.7-tool libunwind7-dev
+    script:
+    - sbt ++$TRAVIS_SCALA_VERSION testNative/run

--- a/core/native/src/main/scala/monocle/std/PlatformSpecificString.scala
+++ b/core/native/src/main/scala/monocle/std/PlatformSpecificString.scala
@@ -1,0 +1,3 @@
+package monocle.std
+
+private [std] trait PlatformSpecificStringOptics

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,6 +5,9 @@ addSbtPlugin("com.typesafe"       % "sbt-mima-plugin"      % "0.1.13")
 addSbtPlugin("org.xerial.sbt"     % "sbt-sonatype"         % "1.1")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh"              % "0.2.20")
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"          % "0.6.14")
+addSbtPlugin("org.scala-native"   % "sbt-crossproject"         % "0.1.0")
+addSbtPlugin("org.scala-native"   % "sbt-scalajs-crossproject" % "0.1.0")
+addSbtPlugin("org.scala-native"   % "sbt-scala-native"         % "0.1.0")
 addSbtPlugin("com.fortysevendeg"  % "sbt-microsites"       % "0.4.0")
 
 scalacOptions += "-deprecation"

--- a/testNative/src/main/scala/monocle/Main.scala
+++ b/testNative/src/main/scala/monocle/Main.scala
@@ -1,0 +1,40 @@
+package monocle
+
+import monocle.std.option.some
+import monocle.state.all._
+
+object Main {
+
+  case class User(name: String, email: Option[String])
+
+  val _name = Lens[User, String](_.name)(n => u => u.copy(name = n))
+  val _email = Lens[User, Option[String]](_.email)(e => u => u.copy(email = e))
+
+  def main(args: Array[String]): Unit = {
+
+    val user = User("John Doe", Some("foo@example.com"))
+
+    assert(_name.get(user) == "John Doe")
+    assert(_name.modify(_.replace(' ', '-'))(user) == user.copy(name = "John-Doe"))
+    assert((_email composePrism some).getOption(user) == Some("foo@example.com"))
+
+    val getSetName = for {
+      n1 <- _name.extract
+      n2 <- _name.assigno(n1)
+    } yield n2
+
+    val setGetName = for {
+      user <- _name.assigno("Eric")
+      name <- _name.extract
+    } yield name
+
+    val setSetName = for {
+      n1 <- _name.assigno("Brian")
+      n2 <- _name.assigno("Luke")
+    } yield n2
+
+    assert(getSetName.exec(user) == user)
+    assert(setGetName.eval(user) == "Eric")
+    assert(setSetName.exec(user) == _name.set("Luke")(user))
+  }
+}


### PR DESCRIPTION
first support: core, state
```
> show coreNative/nativeMissingDependencies
[info] * @java.net.URI
[info] * @java.net.URI::init_class.java.lang.String
[info] * @java.net.URI::toString_class.java.lang.String
[success] Total time: 4 s, completed 2017/03/17 0:27:58
> show stateNative/nativeMissingDependencies
[info] *
[success] Total time: 1 s, completed 2017/03/17 0:28:05
> show testNative/nativeMissingDependencies
[info] *
[success] Total time: 1 s, completed 2017/03/17 0:28:16
```
we need remove `java.net.URI` ...? :thinking:  /cc @densh @MasseGuillaume
https://github.com/julien-truffaut/Monocle/blob/v1.4.0/core/shared/src/main/scala/monocle/std/String.scala#L35-L36