### PR TITLE
Prefer `pure` over `point`.

### DIFF
--- a/core/shared/src/main/scala/monocle/Optional.scala
+++ b/core/shared/src/main/scala/monocle/Optional.scala
@@ -224,7 +224,7 @@ object POptional extends OptionalInstances {
 
       def modifyF[F[_]: Applicative](f: A => F[B])(s: S): F[T] =
         _getOrModify(s).fold(
-          t => Applicative[F].point(t),
+          t => Applicative[F].pure(t),
           a => Applicative[F].map(f(a))(_set(_)(s))
         )
 
@@ -258,7 +258,7 @@ object Optional {
 
       def modifyF[F[_]: Applicative](f: A => F[A])(s: S): F[S] =
         _getOption(s).fold(
-          Applicative[F].point(s))(
+          Applicative[F].pure(s))(
           a => Applicative[F].map(f(a))(_set(_)(s))
         )
 

--- a/core/shared/src/main/scala/monocle/Prism.scala
+++ b/core/shared/src/main/scala/monocle/Prism.scala
@@ -45,7 +45,7 @@ abstract class PPrism[S, T, A, B] extends Serializable { self =>
   /** modify polymorphically the target of a [[PPrism]] with an Applicative function */
   @inline final def modifyF[F[_] : Applicative](f: A => F[B])(s: S): F[T] =
     getOrModify(s).fold(
-      t => Applicative[F].point(t),
+      t => Applicative[F].pure(t),
       a => Applicative[F].map(f(a))(reverseGet)
     )
 

--- a/core/shared/src/main/scala/monocle/function/FilterIndex.scala
+++ b/core/shared/src/main/scala/monocle/function/FilterIndex.scala
@@ -36,7 +36,7 @@ object FilterIndex extends FilterIndexFunctions {
   def fromTraverse[S[_]: Traverse, A](zipWithIndex: S[A] => S[(A, Int)]): FilterIndex[S[A], Int, A] = new FilterIndex[S[A], Int, A]{
     def filterIndex(predicate: Int => Boolean) = new Traversal[S[A], A] {
       def modifyF[F[_]: Applicative](f: A => F[A])(s: S[A]): F[S[A]] =
-        zipWithIndex(s).traverse { case (a, j) => if(predicate(j)) f(a) else Applicative[F].point(a) }
+        zipWithIndex(s).traverse { case (a, j) => if(predicate(j)) f(a) else Applicative[F].pure(a) }
     }
   }
 
@@ -55,7 +55,7 @@ object FilterIndex extends FilterIndexFunctions {
     def filterIndex(predicate: K => Boolean) = new Traversal[Map[K, V], V] {
       def modifyF[F[_]: Applicative](f: V => F[V])(s: Map[K, V]): F[Map[K, V]] =
         s.toList.traverse{ case (k, v) =>
-          (if(predicate(k)) f(v) else v.point[F]).strengthL(k)
+          (if(predicate(k)) f(v) else v.pure[F]).strengthL(k)
         }.map(_.toMap)
     }
   }
@@ -84,7 +84,7 @@ object FilterIndex extends FilterIndexFunctions {
     def filterIndex(predicate: K => Boolean) = new Traversal[K ==>> V, V] {
       def modifyF[F[_]: Applicative](f: V => F[V])(s: K ==>> V): F[K ==>> V] =
         s.toList.traverse{ case (k, v) =>
-          (if(predicate(k)) f(v) else v.point[F]).strengthL(k)
+          (if(predicate(k)) f(v) else v.pure[F]).strengthL(k)
         }.map(==>>.fromList(_))
     }
   }

--- a/core/shared/src/main/scala/monocle/function/Plated.scala
+++ b/core/shared/src/main/scala/monocle/function/Plated.scala
@@ -92,7 +92,7 @@ object Plated extends PlatedFunctions {
       def modifyF[F[_]: Applicative](f: List[A] => F[List[A]])(s: List[A]): F[List[A]] =
         s match {
           case x :: xs => Applicative[F].map(f(xs))(x :: _)
-          case Nil => Applicative[F].point(Nil)
+          case Nil => Applicative[F].pure(Nil)
         }
     }
   }
@@ -102,7 +102,7 @@ object Plated extends PlatedFunctions {
       def modifyF[F[_]: Applicative](f: Stream[A] => F[Stream[A]])(s: Stream[A]): F[Stream[A]] =
         s match {
           case x #:: xs => Applicative[F].map(f(xs))(x #:: _)
-          case Stream() => Applicative[F].point(Stream.empty)
+          case Stream() => Applicative[F].pure(Stream.empty)
         }
     }
   }
@@ -112,7 +112,7 @@ object Plated extends PlatedFunctions {
       def modifyF[F[_]: Applicative](f: String => F[String])(s: String): F[String] =
         s.headOption match {
           case Some(h) => Applicative[F].map(f(s.tail))(h.toString ++ _)
-          case None => Applicative[F].point("")
+          case None => Applicative[F].pure("")
         }
     }
   }
@@ -122,7 +122,7 @@ object Plated extends PlatedFunctions {
       def modifyF[F[_]: Applicative](f: Vector[A] => F[Vector[A]])(s: Vector[A]): F[Vector[A]] =
         s match {
           case h +: t => Applicative[F].map(f(t))(h +: _)
-          case _ => Applicative[F].point(Vector.empty)
+          case _ => Applicative[F].pure(Vector.empty)
         }
     }
   }
@@ -144,7 +144,7 @@ object Plated extends PlatedFunctions {
       def modifyF[F[_]: Applicative](f: Free[S, A] => F[Free[S, A]])(s: Free[S, A]): F[Free[S, A]] =
         s.resume.fold(
           as => Applicative[F].map(Traverse[S].traverse(as)(f))(Free.roll),
-          x => Applicative[F].point(Free.point(x))
+          x => Applicative[F].pure(Free.pure(x))
         )
     }
   }
@@ -154,7 +154,7 @@ object Plated extends PlatedFunctions {
       def modifyF[F[_]: Applicative](f: IList[A] => F[IList[A]])(s: IList[A]): F[IList[A]] =
         s match {
           case ICons(x, xs) => Applicative[F].map(f(xs))(x :: _)
-          case INil() => Applicative[F].point(INil())
+          case INil() => Applicative[F].pure(INil())
         }
     }
   }

--- a/core/shared/src/main/scala/monocle/law/IsoLaws.scala
+++ b/core/shared/src/main/scala/monocle/law/IsoLaws.scala
@@ -26,7 +26,7 @@ case class IsoLaws[S, A](iso: Iso[S, A]) {
     iso.set(a)(s) <==> iso.modify(_ => a)(s)
 
   def consistentModifyModifyId(s: S, f: A => A): IsEq[S] =
-    iso.modify(f)(s) <==> iso.modifyF(a => id.point(f(a)))(s)
+    iso.modify(f)(s) <==> iso.modifyF(a => id.pure(f(a)))(s)
 
   def consistentGetModifyId(s: S): IsEq[A] =
     iso.get(s) <==> iso.modifyF[Const[A, ?]](Const(_))(s).getConst

--- a/core/shared/src/main/scala/monocle/law/LensLaws.scala
+++ b/core/shared/src/main/scala/monocle/law/LensLaws.scala
@@ -28,7 +28,7 @@ case class LensLaws[S, A](lens: Lens[S, A]) {
     lens.set(a)(s) <==> lens.modify(_ => a)(s)
 
   def consistentModifyModifyId(s: S, f: A => A): IsEq[S] =
-    lens.modify(f)(s) <==> lens.modifyF(a => id.point(f(a)))(s)
+    lens.modify(f)(s) <==> lens.modifyF(a => id.pure(f(a)))(s)
 
   def consistentGetModifyId(s: S): IsEq[A] =
     lens.get(s) <==> lens.modifyF[Const[A, ?]](Const(_))(s).getConst

--- a/core/shared/src/main/scala/monocle/law/OptionalLaws.scala
+++ b/core/shared/src/main/scala/monocle/law/OptionalLaws.scala
@@ -32,7 +32,7 @@ case class OptionalLaws[S, A](optional: Optional[S, A]) {
     optional.set(a)(s) <==> optional.modify(_ => a)(s)
 
   def consistentModifyModifyId(s: S, f: A => A): IsEq[S] =
-    optional.modify(f)(s) <==> optional.modifyF(a => id.point(f(a)))(s)
+    optional.modify(f)(s) <==> optional.modifyF(a => id.pure(f(a)))(s)
 
   def consistentGetOptionModifyId(s: S): IsEq[Option[A]] =
     optional.getOption(s) <==> optional.modifyF[Const[Option[A] @@ First, ?]](a => Const(Some(a).first))(s).getConst.unwrap

--- a/core/shared/src/main/scala/monocle/law/PrismLaws.scala
+++ b/core/shared/src/main/scala/monocle/law/PrismLaws.scala
@@ -29,7 +29,7 @@ case class PrismLaws[S, A](prism: Prism[S, A]) {
     prism.set(a)(s) <==> prism.modify(_ => a)(s)
 
   def consistentModifyModifyId(s: S, f: A => A): IsEq[S] =
-    prism.modify(f)(s) <==> prism.modifyF(a => id.point(f(a)))(s)
+    prism.modify(f)(s) <==> prism.modifyF(a => id.pure(f(a)))(s)
 
   def consistentGetOptionModifyId(s: S): IsEq[Option[A]] =
     prism.getOption(s) <==> prism.modifyF[Const[Option[A] @@ First, ?]](a => Const(Some(a).first))(s).getConst.unwrap

--- a/core/shared/src/main/scala/monocle/syntax/Traversal.scala
+++ b/core/shared/src/main/scala/monocle/syntax/Traversal.scala
@@ -105,7 +105,7 @@ trait TraversalBuilder[A, B, T] {
     }
   }
 
-  private def pt[X](x: X) = FreeAp.point[IndexedStore[A, B, ?], X](x)
+  private def pt[X](x: X) = FreeAp.pure[IndexedStore[A, B, ?], X](x)
 
   private def ap[X](h: A, x: => FreeAp[IndexedStore[A, B, ?], B => X]) =
     FreeAp[IndexedStore[A, B, ?], B, X](IndexedStore(identity, h), x)

--- a/example/src/test/scala/monocle/JsonExample.scala
+++ b/example/src/test/scala/monocle/JsonExample.scala
@@ -153,7 +153,7 @@ class JsonExample extends MonocleSuite {
     val plate: Traversal[Json, Json] = new Traversal[Json, Json] {
       def modifyF[F[_]: Applicative](f: Json => F[Json])(a: Json): F[Json] =
         a match {
-          case j@(JsString(_) | JsNumber(_)) => Applicative[F].point(j)
+          case j@(JsString(_) | JsNumber(_)) => Applicative[F].pure(j)
           case JsArray(l) => l.traverse(f).map(JsArray)
           case JsObject(m) => m.traverse(f).map(JsObject)
         }

--- a/test/shared/src/test/scala/monocle/IsoSpec.scala
+++ b/test/shared/src/test/scala/monocle/IsoSpec.scala
@@ -80,8 +80,8 @@ class IsoSpec extends MonocleSuite {
   test("mapping") {
     import scalaz.Id._
 
-    iso.mapping[Id].get(id.point(IntWrapper(3))) shouldEqual id.point(3)
-    iso.mapping[Id].reverseGet(id.point(3)) shouldEqual id.point(IntWrapper(3))
+    iso.mapping[Id].get(id.pure(IntWrapper(3))) shouldEqual id.pure(3)
+    iso.mapping[Id].reverseGet(id.pure(3)) shouldEqual id.pure(IntWrapper(3))
   }
 
   test("apply") {

--- a/test/shared/src/test/scala/monocle/function/PlatedSpec.scala
+++ b/test/shared/src/test/scala/monocle/function/PlatedSpec.scala
@@ -57,7 +57,7 @@ class PlatedSpec extends MonocleSuite {
     }
   }
 
-  test("transform counting Stream using Option.point returns count of changes the same as stream size") {
+  test("transform counting Stream using Option.pure returns count of changes the same as stream size") {
     check { (xs: Stream[Int]) =>
       transformCounting[Stream[Int]](Option(_))(xs) === ((xs.size, xs))
     }


### PR DESCRIPTION
`pure` is also used in Cats, so it reduces the diffs between Scalaz and Cats branches.