### PR TITLE
Update to refined 0.8.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,8 +44,8 @@ lazy val buildSettings = Seq(
 lazy val scalaz             = Def.setting("org.scalaz"      %%% "scalaz-core"          % "7.2.13")
 lazy val shapeless          = Def.setting("com.chuusai"     %%% "shapeless"            % "2.3.2")
 
-lazy val refinedDep         = Def.setting("eu.timepit"      %%% "refined"              % "0.6.1")
-lazy val refinedScalacheck  = Def.setting("eu.timepit"      %%% "refined-scalacheck"   % "0.6.1" % "test")
+lazy val refinedDep         = Def.setting("eu.timepit"      %%% "refined"              % "0.8.2")
+lazy val refinedScalacheck  = Def.setting("eu.timepit"      %%% "refined-scalacheck"   % "0.8.2" % "test")
 
 lazy val discipline         = Def.setting("org.typelevel"   %%% "discipline"           % "0.7.3")
 lazy val scalacheck         = Def.setting("org.scalacheck"  %%% "scalacheck"           % "1.13.5")

--- a/test/shared/src/test/scala/monocle/refined/BitsSpec.scala
+++ b/test/shared/src/test/scala/monocle/refined/BitsSpec.scala
@@ -1,25 +1,11 @@
 package monocle.refined
 
-import eu.timepit.refined._
-import eu.timepit.refined.api.Refined
+import eu.timepit.refined.W
+import eu.timepit.refined.scalacheck.numeric._
 import monocle.MonocleSuite
 import monocle.law.discipline.function.AtTests
-import org.scalacheck.{Arbitrary, Gen}
 
 class BitsSpec extends MonocleSuite {
-  implicit val byteBitsArb: Arbitrary[ByteBits] = Arbitrary(
-    Gen.choose(0, 7).map(Refined.unsafeApply)
-  )
-  implicit val charBitsArb: Arbitrary[CharBits] = Arbitrary(
-    Gen.choose(0, 15).map(Refined.unsafeApply)
-  )
-  implicit val intBitsArb: Arbitrary[IntBits] = Arbitrary(
-    Gen.choose(0, 31).map(Refined.unsafeApply)
-  )
-  implicit val longBitsArb: Arbitrary[LongBits] = Arbitrary(
-    Gen.choose(0, 63).map(Refined.unsafeApply)
-  )
-
   checkAll("Byte at bit", AtTests[Byte, ZeroTo[W.`7`.T], Boolean])
   checkAll("Char at bit", AtTests[Char, ZeroTo[W.`15`.T], Boolean])
   checkAll("Int at bit", AtTests[Int, ZeroTo[W.`31`.T], Boolean])

--- a/test/shared/src/test/scala/monocle/refined/CharSpec.scala
+++ b/test/shared/src/test/scala/monocle/refined/CharSpec.scala
@@ -1,22 +1,13 @@
 package monocle.refined
 
-import eu.timepit.refined.api.Refined
+import eu.timepit.refined.scalacheck.char._
+import eu.timepit.refined.scalacheck.refTypeCogen
 import monocle._
 import monocle.law.discipline.PrismTests
-import org.scalacheck.{Arbitrary, Cogen, Gen}
 
 import scalaz.Equal
 
 class CharSpec extends MonocleSuite {
-  implicit val lowerCaseRefinedCharArb: Arbitrary[LowerCaseChar] =
-    Arbitrary(Gen.alphaLowerChar.map(Refined.unsafeApply))
-
-  implicit val upperCaseRefinedCharArb: Arbitrary[UpperCaseChar] =
-    Arbitrary(Gen.alphaUpperChar.map(Refined.unsafeApply))
-
-  implicit val lowerCaseCoGen: Cogen[LowerCaseChar] = Cogen[Char].contramap[LowerCaseChar](_.value)
-  implicit val upperCaseCoGen: Cogen[UpperCaseChar] = Cogen[Char].contramap[UpperCaseChar](_.value)
-
   implicit val eqLowerCase: Equal[LowerCaseChar] = Equal.equalA[LowerCaseChar]
   implicit val eqUpperCase: Equal[UpperCaseChar] = Equal.equalA[UpperCaseChar]
   implicit val eqChar: Equal[Char] = Equal.equalA[Char]

--- a/test/shared/src/test/scala/monocle/refined/StringsSpec.scala
+++ b/test/shared/src/test/scala/monocle/refined/StringsSpec.scala
@@ -1,18 +1,15 @@
 package monocle.refined
 
-import eu.timepit.refined._
+import eu.timepit.refined.W
+import eu.timepit.refined.scalacheck.refTypeCogen
 import eu.timepit.refined.scalacheck.string.{endsWithArbitrary, startsWithArbitrary}
 import monocle.MonocleSuite
 import monocle.law.discipline.PrismTests
-import org.scalacheck.Cogen
 
 import scalaz.Equal
 
 
 class StringsSpec extends MonocleSuite {
-
-  implicit val startsWithCoGen: Cogen[StartsWithString[W.`"hello"`.T]] = Cogen[String].contramap[StartsWithString[W.`"hello"`.T]](_.value)
-  implicit val endsWithCoGen: Cogen[EndsWithString[W.`"world"`.T]] = Cogen[String].contramap[EndsWithString[W.`"world"`.T]](_.value)
 
   implicit val eqStartsWith: Equal[StartsWithString[W.`"hello"`.T]] = Equal.equalA[StartsWithString[W.`"hello"`.T]]
   implicit val eqEndsWith: Equal[EndsWithString[W.`"world"`.T]] = Equal.equalA[EndsWithString[W.`"world"`.T]]


### PR DESCRIPTION
This also makes use of refined-scalacheck instances in tests.