### PR TITLE
Add state syntax for traversal

### DIFF
--- a/example/src/test/scala/monocle/state/StateExample.scala
+++ b/example/src/test/scala/monocle/state/StateExample.scala
@@ -1,6 +1,6 @@
 package monocle.state
 
-import monocle.{MonocleSuite, Optional, Setter, Getter}
+import monocle.{MonocleSuite, Optional, Setter, Getter, PTraversal}
 import monocle.macros.GenLens
 
 class StateExample extends MonocleSuite {
@@ -246,5 +246,58 @@ class StateExample extends MonocleSuite {
     val upper = _nameGet extracts (_.toUpperCase)
 
     upper.run(p) shouldEqual ((Person("John", 30), "JOHN"))
+  }
+
+  // first and second projections of a triple
+  def _pi12Tr[A, B, C] = PTraversal.fromStore[(A, A, C), (B, B, C), A, B] {
+    case (a1, a2, c) => (a1 ~ a2)((_, _, c))
+  }
+
+  test("extract for Traversal"){
+    val both = _pi12Tr[Int, Int, Char].extract
+
+    both.run((1, 2, 'a')) shouldEqual (((1, 2, 'a'), List(1, 2)))
+  }
+
+  test("extracts for Traversal"){
+    val sum = _pi12Tr[Int, Int, Char].extracts(_.sum)
+
+    sum.run((1, 2, 'a')) shouldEqual (((1, 2, 'a'), 3))
+  }
+
+  test("mod for Traversal"){
+    val len = _pi12Tr[String, Int, Char].mod(_.length)
+
+    len.run(("john", "doe", 'a')) shouldEqual (((4, 3, 'a'), List(4, 3)))
+  }
+
+  test("modo for Traversal"){
+    val len = _pi12Tr[String, Int, Char].modo(_.length)
+
+    len.run(("john", "doe", 'a')) shouldEqual (((4, 3, 'a'), List("john", "doe")))
+  }
+
+  test("mod_ for Traversal"){
+    val len = _pi12Tr[String, Int, Char].mod_(_.length)
+
+    len.run(("john", "doe", 'a')) shouldEqual (((4, 3, 'a'), ()))
+  }
+
+  test("assign for Traversal"){
+    val toTrue = _pi12Tr[Int, Boolean, Char].assign(true)
+
+    toTrue.run((1, 2, 'a')) shouldEqual (((true, true, 'a'), List(true, true)))
+  }
+
+  test("assigno for Traversal"){
+    val toTrue = _pi12Tr[Int, Boolean, Char].assigno(true)
+
+    toTrue.run((1, 2, 'a')) shouldEqual (((true, true, 'a'), List(1, 2)))
+  }
+
+  test("assign_ for Traversal"){
+    val toTrue = _pi12Tr[Int, Boolean, Char].assign_(true)
+
+    toTrue.run((1, 2, 'a')) shouldEqual (((true, true, 'a'), ()))
   }
 }

--- a/example/src/test/scala/monocle/state/StateExample.scala
+++ b/example/src/test/scala/monocle/state/StateExample.scala
@@ -250,7 +250,7 @@ class StateExample extends MonocleSuite {
 
   // first and second projections of a triple
   def _pi12Tr[A, B, C] = PTraversal.fromStore[(A, A, C), (B, B, C), A, B] {
-    case (a1, a2, c) => (a1 ~ a2)((_, _, c))
+    case (a1, a2, c) => (toTraversalBuilder[A, B, (B, B, C)](a1) ~ a2)((_, _, c))
   }
 
   test("extract for Traversal"){

--- a/state/shared/src/main/scala/monocle/state/All.scala
+++ b/state/shared/src/main/scala/monocle/state/All.scala
@@ -4,4 +4,5 @@ object all extends StateLensSyntax
   with StateOptionalSyntax
   with StateGetterSyntax
   with StateSetterSyntax
+  with StateTraversalSyntax
   with ReaderGetterSyntax

--- a/state/shared/src/main/scala/monocle/state/StateTraversalSyntax.scala
+++ b/state/shared/src/main/scala/monocle/state/StateTraversalSyntax.scala
@@ -1,0 +1,55 @@
+package monocle.state
+
+import monocle.PTraversal
+
+import scalaz.{IndexedState, State}
+
+trait StateTraversalSyntax {
+  implicit def toStateTraversalOps[S, T, A, B](traversal: PTraversal[S, T, A, B]): StateTraversalOps[S, T, A, B] =
+    new StateTraversalOps[S, T, A, B](traversal)
+}
+
+final class StateTraversalOps[S, T, A, B](traversal: PTraversal[S, T, A, B]) {
+  /** transforms a PTraversal into a State */
+  def toState: State[S, List[A]] =
+    State(s => (s, traversal.getAll(s)))
+
+  /** alias for toState */
+  def st: State[S, List[A]] =
+    toState
+
+  /** extracts the values viewed through the traversal */
+  def extract: State[S, List[A]] =
+    toState
+
+  /** extracts the values viewed through the traversal and applied `f` over it */
+  def extracts[B](f: List[A] => B): State[S, B] =
+    extract.map(f)
+
+  /** modify the values viewed through the traversal and returns its *new* values */
+  def mod(f: A => B): IndexedState[S, T, List[B]] =
+    IndexedState(s => {
+      val as = traversal.getAll(s)
+      (traversal.modify(f)(s), as.map(f))
+    })
+
+  /** modify the values viewed through the traversal and returns its *old* values */
+  def modo(f: A => B): IndexedState[S, T, List[A]] =
+    toState.leftMap(traversal.modify(f))
+
+  /** modify the values viewed through the traversal and ignores both values */
+  def mod_(f: A => B): IndexedState[S, T, Unit] =
+    IndexedState(s => (traversal.modify(f)(s), ()))
+
+  /** set the values viewed through the traversal and returns its *new* values */
+  def assign(b: B): IndexedState[S, T, List[B]] =
+    mod(_ => b)
+
+  /** set the values viewed through the traversal and returns its *old* values */
+  def assigno(b: B): IndexedState[S, T, List[A]] =
+    modo(_ => b)
+
+  /** set the values viewed through the traversal and ignores both values */
+  def assign_(b: B): IndexedState[S, T, Unit] =
+    mod_(_ => b)
+}

--- a/test/shared/src/test/scala/monocle/MonocleSuite.scala
+++ b/test/shared/src/test/scala/monocle/MonocleSuite.scala
@@ -22,4 +22,5 @@ trait MonocleSuite extends FunSuite
                       with StateOptionalSyntax
                       with StateGetterSyntax
                       with StateSetterSyntax
+                      with StateTraversalSyntax
                       with ReaderGetterSyntax


### PR DESCRIPTION
Adds syntax for `Traversal`s in the state module, including `extract`, `mod`, `assign` and related methods.