### PR TITLE
cats 1.0.0-RC1

### DIFF
--- a/bench/src/main/scala/monocle/bench/BenchModel.scala
+++ b/bench/src/main/scala/monocle/bench/BenchModel.scala
@@ -1,5 +1,6 @@
 package monocle.bench
 
+import scala.collection.immutable.SortedMap
 import scala.util.Random
 
 
@@ -35,7 +36,7 @@ object BenchModel {
   case class Point3(x: Int, y: Int, z: Int)
   val p = Point3(2, 10, 24)
 
-  val map = 1.to(200).map(_ -> 5).toMap
+  val map = SortedMap(1.to(200).map(_ -> 5): _*)
 
 
   case class IntWrapper0(i: Int)

--- a/bench/src/main/scala/monocle/bench/MonocleTraversalBench.scala
+++ b/bench/src/main/scala/monocle/bench/MonocleTraversalBench.scala
@@ -4,13 +4,16 @@ import monocle.bench.BenchModel._
 import monocle.{PTraversal, Traversal}
 import org.openjdk.jmh.annotations.{Benchmark, Scope, State}
 
-import cats.instances.map._
+import cats.instances.sortedMap._
+import cats.instances.int._
+
+import scala.collection.immutable.SortedMap
 
 @State(Scope.Benchmark)
 class MonocleTraversalBench {
 
   val point3Traversal = Traversal.apply3[Point3, Int](_.x, _.y, _.z)((x, y, z, _) => Point3(x, y, z))
-  val iMapTraversal = PTraversal.fromTraverse[Map[Int, ?], Int, Int]
+  val iMapTraversal = PTraversal.fromTraverse[SortedMap[Int, ?], Int, Int]
 
 
   @Benchmark def caseClassGetAll() = point3Traversal.getAll(p)

--- a/build.sbt
+++ b/build.sbt
@@ -39,13 +39,13 @@ lazy val buildSettings = Seq(
   scmInfo := Some(ScmInfo(url("https://github.com/julien-truffaut/Monocle"), "scm:git:git@github.com:julien-truffaut/Monocle.git"))
 )
 
-lazy val catsVersion = "1.0.0-MF"
+lazy val catsVersion = "1.0.0-RC1"
 
 
 lazy val cats              = Def.setting("org.typelevel"              %%% "cats-core"          % catsVersion)
 lazy val catsFree          = Def.setting("org.typelevel"              %%% "cats-free"          % catsVersion)
 lazy val catsLaws          = Def.setting("org.typelevel"              %%% "cats-laws"          % catsVersion)
-lazy val newts             = Def.setting("com.github.julien-truffaut" %%% "newts-core"         % "0.3.0-MF-2")
+lazy val newts             = Def.setting("com.github.julien-truffaut" %%% "newts-core"         % "0.3.0-RC1")
 lazy val scalaz            = Def.setting("org.scalaz"                 %%% "scalaz-core"        % "7.2.13")
 lazy val shapeless         = Def.setting("com.chuusai"                %%% "shapeless"          % "2.3.2")
 lazy val refinedDep         = Def.setting("eu.timepit"      %%% "refined"              % "0.8.2")

--- a/core/shared/src/main/scala/monocle/Getter.scala
+++ b/core/shared/src/main/scala/monocle/Getter.scala
@@ -1,6 +1,6 @@
 package monocle
 
-import cats.{Monoid, Cartesian => Zip}
+import cats.{Monoid, Semigroupal => Zip}
 import cats.arrow.{Arrow, Choice}
 import cats.implicits._
 import scala.{Either => \/}

--- a/core/shared/src/main/scala/monocle/Setter.scala
+++ b/core/shared/src/main/scala/monocle/Setter.scala
@@ -1,8 +1,8 @@
 package monocle
 
-import cats.Functor
+import cats.{ Contravariant, Functor }
 import cats.arrow.Choice
-import cats.functor.{Contravariant, Profunctor}
+import cats.arrow.Profunctor
 import cats.syntax.either._
 import scala.{Either => \/}
 

--- a/core/shared/src/main/scala/monocle/function/At.scala
+++ b/core/shared/src/main/scala/monocle/function/At.scala
@@ -3,6 +3,7 @@ package monocle.function
 import monocle.{Iso, Lens}
 
 import scala.annotation.implicitNotFound
+import scala.collection.immutable.SortedMap
 
 /**
  * Typeclass that defines a [[Lens]] from an `S` to an `A` at an index `I`
@@ -40,8 +41,8 @@ object At extends AtFunctions {
   /** Std instances                                                                               */
   /************************************************************************************************/
 
-  implicit def atMap[K, V]: At[Map[K, V], K, Option[V]] = new At[Map[K, V], K, Option[V]]{
-    def at(i: K) = Lens{m: Map[K, V] => m.get(i)}(optV => map => optV.fold(map - i)(v => map + (i -> v)))
+  implicit def atSortedMap[K, V]: At[SortedMap[K, V], K, Option[V]] = new At[SortedMap[K, V], K, Option[V]]{
+    def at(i: K) = Lens{m: SortedMap[K, V] => m.get(i)}(optV => map => optV.fold(map - i)(v => map + (i -> v)))
   }
 
   implicit def atSet[A]: At[Set[A], A, Boolean] = new At[Set[A], A, Boolean] {

--- a/core/shared/src/main/scala/monocle/function/Each.scala
+++ b/core/shared/src/main/scala/monocle/function/Each.scala
@@ -3,7 +3,7 @@ package monocle.function
 import monocle.{Iso, PTraversal, Traversal}
 
 import scala.annotation.implicitNotFound
-import cats.{Applicative, Traverse}
+import cats.{Applicative, Order, Traverse}
 
 /**
  * Typeclass that defines a [[Traversal]] from a monomorphic container `S` to all of its elements of type `A`
@@ -39,9 +39,10 @@ object Each extends EachFunctions {
   /** Std instances                                                                               */
   /************************************************************************************************/
   import cats.instances.list._
-  import cats.instances.map._
+  import cats.instances.sortedMap._
   import cats.instances.stream._
   import cats.instances.vector._
+  import scala.collection.immutable.SortedMap
   import scala.util.Try
 
   implicit def eitherEach[A, B]: Each[Either[A, B], B] = new Each[Either[A, B], B] {
@@ -50,7 +51,7 @@ object Each extends EachFunctions {
 
   implicit def listEach[A]: Each[List[A], A] = fromTraverse
 
-  implicit def mapEach[K, V]: Each[Map[K, V], V] = fromTraverse[Map[K, ?], V]
+  implicit def mapEach[K: Order, V]: Each[SortedMap[K, V], V] = fromTraverse[SortedMap[K, ?], V]
 
   implicit def optEach[A]: Each[Option[A], A] = new Each[Option[A], A] {
     def each = monocle.std.option.some[A].asTraversal

--- a/core/shared/src/main/scala/monocle/function/Empty.scala
+++ b/core/shared/src/main/scala/monocle/function/Empty.scala
@@ -2,7 +2,10 @@ package monocle.function
 
 import monocle.{Iso, Prism}
 
+import cats.Order
+
 import scala.annotation.implicitNotFound
+import scala.collection.immutable.SortedMap
 
 /**
  * Typeclass that defines a [[Prism]] from an `S` and its empty value
@@ -40,8 +43,8 @@ object Empty extends EmptyFunctions {
     val empty = Prism[List[A], Unit](l => if(l.isEmpty) Some(()) else None)(_ => List.empty)
   }
 
-  implicit def mapEmpty[K, V]: Empty[Map[K, V]] = new Empty[Map[K, V]] {
-    val empty = Prism[Map[K, V], Unit](m => if(m.isEmpty) Some(()) else None)(_ => Map.empty)
+  implicit def sortedMapEmpty[K, V](implicit ok: Order[K]): Empty[SortedMap[K, V]] = new Empty[SortedMap[K, V]] {
+    val empty = Prism[SortedMap[K, V], Unit](m => if(m.isEmpty) Some(()) else None)(_ => SortedMap.empty(ok.toOrdering))
   }
 
   implicit def optionEmpty[A]: Empty[Option[A]] = new Empty[Option[A]] {

--- a/core/shared/src/main/scala/monocle/function/Index.scala
+++ b/core/shared/src/main/scala/monocle/function/Index.scala
@@ -1,8 +1,11 @@
 package monocle.function
 
+import cats.Order
+
 import monocle.{Iso, Optional}
 
 import scala.annotation.implicitNotFound
+import scala.collection.immutable.SortedMap
 import scala.util.Try
 
 /**
@@ -47,7 +50,7 @@ object Index extends IndexFunctions{
     )
   }
 
-  implicit def mapIndex[K, V]: Index[Map[K, V], K, V] = fromAt
+  implicit def sortedMapIndex[K: Order, V]: Index[SortedMap[K, V], K, V] = fromAt
 
   implicit def streamIndex[A]: Index[Stream[A], Int, A] = new Index[Stream[A], Int, A] {
     def index(i: Int) = Optional[Stream[A], A](

--- a/example/src/test/scala/monocle/HttpRequestExample.scala
+++ b/example/src/test/scala/monocle/HttpRequestExample.scala
@@ -1,6 +1,7 @@
 package monocle
 
 import monocle.macros.{GenLens, GenIso, GenPrism}
+import scala.collection.immutable.SortedMap
 
 /**
  * Show how could we use Monocle to handle custom case classes, objects
@@ -10,14 +11,14 @@ class HttpRequestExample extends MonocleSuite {
 
   val r1 = HttpRequest(
     GET,
-    URI("localhost", 8080, "/ping", Map("hop" -> "5")),
-    Map("socket_timeout" -> "20", "connection_timeout" -> "10"),
+    URI("localhost", 8080, "/ping", SortedMap("hop" -> "5")),
+    SortedMap("socket_timeout" -> "20", "connection_timeout" -> "10"),
     "")
 
   val r2 = HttpRequest(
     POST,
-    URI("gooogle.com", 443, "/search", Map("keyword" -> "monocle")),
-    Map.empty,
+    URI("gooogle.com", 443, "/search", SortedMap("keyword" -> "monocle")),
+    SortedMap.empty,
     "")
 
   val method = GenLens[HttpRequest](_.method)
@@ -85,6 +86,6 @@ object HttpRequestExample {
   case object GET   extends HttpMethod
   case object POST  extends HttpMethod
 
-  case class URI(host: String, port: Int, path: String, query: Map[String, String])
-  case class HttpRequest(method: HttpMethod, uri: URI, headers: Map[String, String], body: String)
+  case class URI(host: String, port: Int, path: String, query: SortedMap[String, String])
+  case class HttpRequest(method: HttpMethod, uri: URI, headers: SortedMap[String, String], body: String)
 }

--- a/example/src/test/scala/monocle/JsonExample.scala
+++ b/example/src/test/scala/monocle/JsonExample.scala
@@ -1,6 +1,7 @@
 package monocle
 
 import monocle.function.Plated
+import scala.collection.immutable.SortedMap
 
 /**
  * Show how could we use Optics to manipulate some Json AST
@@ -12,23 +13,23 @@ class JsonExample extends MonocleSuite {
   case class JsString(s: String) extends Json
   case class JsNumber(n: Int) extends Json
   case class JsArray(l: List[Json]) extends Json
-  case class JsObject(m: Map[String, Json]) extends Json
+  case class JsObject(m: SortedMap[String, Json]) extends Json
 
   val jsString = Prism[Json, String]{ case JsString(s) => Some(s); case _ => None}(JsString.apply)
   val jsNumber = Prism[Json, Int]{ case JsNumber(n) => Some(n); case _ => None}(JsNumber.apply)
   val jsArray  = Prism[Json, List[Json]]{ case JsArray(a) => Some(a); case _ => None}(JsArray.apply)
-  val jsObject = Prism[Json, Map[String, Json]]{ case JsObject(m) => Some(m); case _ => None}(JsObject.apply)
+  val jsObject = Prism[Json, SortedMap[String, Json]]{ case JsObject(m) => Some(m); case _ => None}(JsObject.apply)
 
-  val json: Json = JsObject(Map(
+  val json: Json = JsObject(SortedMap(
     "first_name" -> JsString("John"),
     "last_name"  -> JsString("Doe"),
     "age"        -> JsNumber(28),
     "siblings"   -> JsArray(List(
-      JsObject(Map(
+      JsObject(SortedMap(
         "first_name" -> JsString("Elia"),
         "age"        -> JsNumber(23)
       )),
-      JsObject(Map(
+      JsObject(SortedMap(
         "first_name" -> JsString("Robert"),
         "age"        -> JsNumber(25)
       ))
@@ -49,16 +50,16 @@ class JsonExample extends MonocleSuite {
               composePrism    jsObject
               composeOptional index("first_name")
               composePrism    jsString
-    ).set("Robert Jr.")(json) shouldEqual JsObject(Map(
+    ).set("Robert Jr.")(json) shouldEqual JsObject(SortedMap(
       "first_name" -> JsString("John"),
       "last_name"  -> JsString("Doe"),
       "age"        -> JsNumber(28),
       "siblings"   -> JsArray(List(
-        JsObject(Map(
+        JsObject(SortedMap(
           "first_name" -> JsString("Elia"),
           "age"        -> JsNumber(23)
         )),
-        JsObject(Map(
+        JsObject(SortedMap(
           "first_name" -> JsString("Robert Jr."), // name is updated
           "age"        -> JsNumber(25)
         ))
@@ -67,32 +68,32 @@ class JsonExample extends MonocleSuite {
   }
 
   test("Use at to add delete fields") {
-    (jsObject composeLens at("nick_name")).set(Some(JsString("Jojo")))(json) shouldEqual JsObject(Map(
+    (jsObject composeLens at("nick_name")).set(Some(JsString("Jojo")))(json) shouldEqual JsObject(SortedMap(
       "first_name" -> JsString("John"),
       "nick_name"  -> JsString("Jojo"), // new field
       "last_name"  -> JsString("Doe"),
       "age"        -> JsNumber(28),
       "siblings"   -> JsArray(List(
-        JsObject(Map(
+        JsObject(SortedMap(
           "first_name" -> JsString("Elia"),
           "age"        -> JsNumber(23)
         )),
-        JsObject(Map(
+        JsObject(SortedMap(
           "first_name" -> JsString("Robert"),
           "age"        -> JsNumber(25)
         ))
       ))
     ))
 
-    (jsObject composeLens at("age")).set(None)(json) shouldEqual JsObject(Map(
+    (jsObject composeLens at("age")).set(None)(json) shouldEqual JsObject(SortedMap(
       "first_name" -> JsString("John"),
       "last_name"  -> JsString("Doe"), // John is ageless now
       "siblings"   -> JsArray(List(
-        JsObject(Map(
+        JsObject(SortedMap(
           "first_name" -> JsString("Elia"),
           "age"        -> JsNumber(23)
         )),
-        JsObject(Map(
+        JsObject(SortedMap(
           "first_name" -> JsString("Robert"),
           "age"        -> JsNumber(25)
         ))
@@ -104,16 +105,16 @@ class JsonExample extends MonocleSuite {
     (jsObject composeTraversal filterIndex((_: String).contains("name"))
               composePrism     jsString
               composeOptional  headOption
-    ).modify(_.toLower)(json) shouldEqual JsObject(Map(
+    ).modify(_.toLower)(json) shouldEqual JsObject(SortedMap(
       "first_name" -> JsString("john"), // starts with lower case
       "last_name"  -> JsString("doe"),  // starts with lower case
       "age"        -> JsNumber(28),
       "siblings"   -> JsArray(List(
-        JsObject(Map(
+        JsObject(SortedMap(
           "first_name" -> JsString("Elia"),
           "age"        -> JsNumber(23)
         )),
-        JsObject(Map(
+        JsObject(SortedMap(
           "first_name" -> JsString("Robert"),
           "age"        -> JsNumber(25)
         ))
@@ -127,16 +128,16 @@ class JsonExample extends MonocleSuite {
               composePrism     jsObject
               composeOptional  index("age")
               composePrism     jsNumber
-    ).modify(_ + 1)(json) shouldEqual JsObject(Map(
+    ).modify(_ + 1)(json) shouldEqual JsObject(SortedMap(
       "first_name" -> JsString("John"),
       "last_name"  -> JsString("Doe"),
       "age"        -> JsNumber(28),
       "siblings"   -> JsArray(List(
-        JsObject(Map(
+        JsObject(SortedMap(
           "first_name" -> JsString("Elia"),
           "age"        -> JsNumber(24)    // Elia is older
         )),
-        JsObject(Map(
+        JsObject(SortedMap(
           "first_name" -> JsString("Robert"),
           "age"        -> JsNumber(26)    // Robert is older
         ))
@@ -155,7 +156,7 @@ class JsonExample extends MonocleSuite {
         a match {
           case j@(JsString(_) | JsNumber(_)) => Applicative[F].pure(j)
           case JsArray(l) => l.traverse(f).map(JsArray)
-          case JsObject(m) => Traverse[Map[String, ?]].traverse(m)(f).map(JsObject)
+          case JsObject(m) => Traverse[SortedMap[String, ?]].traverse(m)(f).map(JsObject)
         }
     }
   }
@@ -166,16 +167,16 @@ class JsonExample extends MonocleSuite {
         val u = s.toUpperCase
         if (s != u) Some(JsString(u)) else None
       case _ => None
-    }(json) shouldEqual JsObject(Map(
+    }(json) shouldEqual JsObject(SortedMap(
       "first_name" -> JsString("JOHN"),
       "last_name"  -> JsString("DOE"),
       "age"        -> JsNumber(28),
       "siblings"   -> JsArray(List(
-        JsObject(Map(
+        JsObject(SortedMap(
           "first_name" -> JsString("ELIA"),
           "age"        -> JsNumber(23)
         )),
-        JsObject(Map(
+        JsObject(SortedMap(
           "first_name" -> JsString("ROBERT"),
           "age"        -> JsNumber(25)
         ))

--- a/example/src/test/scala/monocle/function/AtExample.scala
+++ b/example/src/test/scala/monocle/function/AtExample.scala
@@ -5,27 +5,21 @@ import monocle.refined._
 import shapeless.test.illTyped
 import eu.timepit.refined.auto._
 
-import scala.collection.immutable.{Map => IMap}
+import scala.collection.immutable.SortedMap
 
 class AtExample extends MonocleSuite {
 
-  test("at creates a Lens from a Map, IMap to an optional value") {
-    (Map("One" -> 2, "Two" -> 2) applyLens at("Two") get) shouldEqual Some(2)
+  test("at creates a Lens from a SortedMap, IMap to an optional value") {
+    (SortedMap("One" -> 2, "Two" -> 2) applyLens at("Two") get) shouldEqual Some(2)
 
-    (Map("One" -> 1, "Two" -> 2) applyLens at("One") set Some(-1))  shouldEqual Map("One" -> -1, "Two" -> 2)
-
-    (IMap("One" -> 2, "Two" -> 2) applyLens at("Two") get) shouldEqual Some(2)
-
-    (IMap("One" -> 1, "Two" -> 2) applyLens at("One") set Some(-1))  shouldEqual IMap("One" -> -1, "Two" -> 2)
+    (SortedMap("One" -> 1, "Two" -> 2) applyLens at("One") set Some(-1))  shouldEqual SortedMap("One" -> -1, "Two" -> 2)
 
 
     // can delete a value
-    (Map("One" -> 1, "Two" -> 2) applyLens at("Two") set None) shouldEqual Map("One" -> 1)
-    (IMap("One" -> 1, "Two" -> 2) applyLens at("Two") set None) shouldEqual IMap("One" -> 1)
+    (SortedMap("One" -> 1, "Two" -> 2) applyLens at("Two") set None) shouldEqual SortedMap("One" -> 1)
 
     // add a new value
-    (Map("One" -> 1, "Two" -> 2) applyLens at("Three") set Some(3)) shouldEqual Map("One" -> 1, "Two" -> 2, "Three" -> 3)
-    (IMap("One" -> 1, "Two" -> 2) applyLens at("Three") set Some(3)) shouldEqual IMap("One" -> 1, "Two" -> 2, "Three" -> 3)
+    (SortedMap("One" -> 1, "Two" -> 2) applyLens at("Three") set Some(3)) shouldEqual SortedMap("One" -> 1, "Two" -> 2, "Three" -> 3)
   }
 
   test("at creates a Lens from a Set to an optional element of the Set") {
@@ -53,8 +47,8 @@ class AtExample extends MonocleSuite {
     ('x' applyLens at(0: CharBits) set true) shouldEqual 'y'
   }
 
-  test("remove deletes an element of a Map") {
-    remove("Foo")(Map("Foo" -> 1, "Bar" -> 2)) shouldEqual Map("Bar" -> 2)
+  test("remove deletes an element of a SortedMap") {
+    remove("Foo")(SortedMap("Foo" -> 1, "Bar" -> 2)) shouldEqual SortedMap("Bar" -> 2)
   }
 
 }

--- a/example/src/test/scala/monocle/function/EachExample.scala
+++ b/example/src/test/scala/monocle/function/EachExample.scala
@@ -2,7 +2,7 @@ package monocle.function
 
 import monocle.MonocleSuite
 
-import scala.collection.immutable.{List => IList, Map => IMap}
+import scala.collection.immutable.SortedMap
 import cats.data.OneAnd
 
 class EachExample extends MonocleSuite {
@@ -14,15 +14,13 @@ class EachExample extends MonocleSuite {
 
   test("Each can be used on List, IList, Vector, Stream and OneAnd") {
     (List(1,2)   applyTraversal each modify( _ + 1)) shouldEqual List(2,3)
-    (IList(1,2)  applyTraversal each modify( _ + 1)) shouldEqual IList(2,3)
     (Stream(1,2) applyTraversal each modify( _ + 1)) shouldEqual Stream(2,3)
     (Vector(1,2) applyTraversal each modify( _ + 1)) shouldEqual Vector(2,3)
     (OneAnd(1, List(2,3)) applyTraversal each modify( _ + 1)) shouldEqual OneAnd(2, List(3,4))
   }
 
   test("Each can be used on Map, IMap to update all values") {
-    (Map("One" -> 1, "Two" -> 2) applyTraversal each modify( _ + 1)) shouldEqual Map("One" -> 2, "Two" -> 3)
-    (IMap("One" -> 1, "Two" -> 2) applyTraversal each modify( _ + 1)) shouldEqual IMap("One" -> 2, "Two" -> 3)
+    (SortedMap("One" -> 1, "Two" -> 2) applyTraversal each modify( _ + 1)) shouldEqual SortedMap("One" -> 2, "Two" -> 3)
   }
 
   test("Each can be used on tuple of same type") {

--- a/example/src/test/scala/monocle/function/EmptyExample.scala
+++ b/example/src/test/scala/monocle/function/EmptyExample.scala
@@ -2,6 +2,7 @@ package monocle.function
 
 import monocle.MonocleSuite
 import monocle.function.all.{empty => mempty}
+import scala.collection.immutable.SortedMap
 
 class EmptyExample extends MonocleSuite {
 
@@ -15,7 +16,7 @@ class EmptyExample extends MonocleSuite {
 
   test("_empty return the empty value of a given type") {
     _empty[List[Int]]        shouldEqual List.empty[Int]
-    _empty[Map[Int, String]] shouldEqual Map.empty[Int, String]
+    _empty[SortedMap[Int, String]] shouldEqual SortedMap.empty[Int, String]
     _empty[String]           shouldEqual ""
   }
 
@@ -26,5 +27,5 @@ class EmptyExample extends MonocleSuite {
     _isEmpty(List.empty)  shouldEqual true
     _isEmpty("")          shouldEqual true
   }
-  
+
 }

--- a/example/src/test/scala/monocle/function/FilterIndexExample.scala
+++ b/example/src/test/scala/monocle/function/FilterIndexExample.scala
@@ -2,17 +2,15 @@ package monocle.function
 
 import monocle.MonocleSuite
 
-import scala.collection.immutable.{List => IList, Map => IMap}
+import scala.collection.immutable.SortedMap
 
 class FilterIndexExample extends MonocleSuite {
 
-  test("filterIndexes creates Traversal from a Map, IMap to all values where the index matches the predicate") {
+  test("filterIndexes creates Traversal from a SortedMap, IMap to all values where the index matches the predicate") {
 
-    (Map("One" -> 1, "Two" -> 2) applyTraversal filterIndex{k: String => k.toLowerCase.contains("o")} getAll)  shouldEqual List(1, 2)
-    (IMap("One" -> 1, "Two" -> 2) applyTraversal filterIndex{k: String => k.toLowerCase.contains("o")} getAll) shouldEqual List(1, 2)
+    (SortedMap("One" -> 1, "Two" -> 2) applyTraversal filterIndex{k: String => k.toLowerCase.contains("o")} getAll)  shouldEqual List(1, 2)
 
-    (Map("One" -> 1, "Two" -> 2) applyTraversal filterIndex{k: String => k.startsWith("T")} set 3) shouldEqual Map("One" -> 1, "Two" -> 3)
-    (IMap("One" -> 1, "Two" -> 2) applyTraversal filterIndex{k: String => k.startsWith("T")} set 3) shouldEqual IMap("One" -> 1, "Two" -> 3)
+    (SortedMap("One" -> 1, "Two" -> 2) applyTraversal filterIndex{k: String => k.startsWith("T")} set 3) shouldEqual SortedMap("One" -> 1, "Two" -> 3)
 
   }
 
@@ -21,7 +19,6 @@ class FilterIndexExample extends MonocleSuite {
     (List(1,3,5,7) applyTraversal filterIndex{ i: Int => i%2 == 0 } getAll) shouldEqual List(1,5)
 
     (List(1,3,5,7)   applyTraversal filterIndex{ i: Int => i >= 2 } modify(_ + 2)) shouldEqual List(1,3,7,9)
-    (IList(1,3,5,7)  applyTraversal filterIndex{ i: Int => i >= 2 } modify(_ + 2)) shouldEqual IList(1,3,7,9)
     (Vector(1,3,5,7) applyTraversal filterIndex{ i: Int => i >= 2 } modify(_ + 2)) shouldEqual Vector(1,3,7,9)
     (Stream(1,3,5,7) applyTraversal filterIndex{ i: Int => i >= 2 } modify(_ + 2)) shouldEqual Stream(1,3,7,9)
 

--- a/example/src/test/scala/monocle/function/IndexExample.scala
+++ b/example/src/test/scala/monocle/function/IndexExample.scala
@@ -2,17 +2,15 @@ package monocle.function
 
 import monocle.MonocleSuite
 
-import scala.collection.immutable.{Map => IMap}
+import scala.collection.immutable.SortedMap
 import cats.data.OneAnd
 
 class IndexExample extends MonocleSuite {
 
-  test("index creates an Optional from a Map, IMap to a value at the index") {
-    (Map("One" -> 1, "Two" -> 2) applyOptional index("One") getOption) shouldEqual Some(1)
-    (IMap("One" -> 1, "Two" -> 2) applyOptional index("One") getOption) shouldEqual Some(1)
+  test("index creates an Optional from a SortedMap, IMap to a value at the index") {
+    (SortedMap("One" -> 1, "Two" -> 2) applyOptional index("One") getOption) shouldEqual Some(1)
 
-    (Map("One" -> 1, "Two" -> 2) applyOptional index("One") set 2) shouldEqual Map("One" -> 2, "Two" -> 2)
-    (IMap("One" -> 1, "Two" -> 2) applyOptional index("One") set 2) shouldEqual IMap("One" -> 2, "Two" -> 2)
+    (SortedMap("One" -> 1, "Two" -> 2) applyOptional index("One") set 2) shouldEqual SortedMap("One" -> 2, "Two" -> 2)
   }
 
   test("index creates an Optional from a List, IList, Vector or Stream to a value at the index") {

--- a/test/shared/src/test/scala/monocle/GetterSpec.scala
+++ b/test/shared/src/test/scala/monocle/GetterSpec.scala
@@ -1,8 +1,7 @@
 package monocle
 
-import cats.{Cartesian => Zip}
-import cats.arrow.{Arrow, Category, Compose, Choice}
-import cats.functor.Profunctor
+import cats.{Semigroupal => Zip}
+import cats.arrow.{Arrow, Category, Compose, Choice, Profunctor}
 import scala.{Left => -\/}
 
 class GetterSpec extends MonocleSuite {

--- a/test/shared/src/test/scala/monocle/function/AtSpec.scala
+++ b/test/shared/src/test/scala/monocle/function/AtSpec.scala
@@ -1,20 +1,22 @@
 package monocle.function
 
+import cats.Order
 import monocle.MonocleSuite
 import monocle.law.discipline.function.AtTests
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import scala.collection.immutable.SortedMap
 
 class AtSpec extends MonocleSuite with GeneratorDrivenPropertyChecks {
 
-  implicit def mmapAt[K, V]: At[MMap[K, V], K, Option[V]] = At.fromIso(MMap.toMap)
+  implicit def mmapAt[K: Order, V]: At[MMap[K, V], K, Option[V]] = At.fromIso(MMap.toSortedMap)
 
   checkAll("fromIso", AtTests[MMap[Int, String], Int, Option[String]])
 
   test("remove deletes a key") {
 
-    val mapAndIndexGen: Gen[(Map[Int, String], Int)] = for {
-      m <- Arbitrary.arbitrary[Map[Int, String]]
+    val mapAndIndexGen: Gen[(SortedMap[Int, String], Int)] = for {
+      m <- Arbitrary.arbitrary[SortedMap[Int, String]]
       i <- if(m.isEmpty) Arbitrary.arbInt.arbitrary
       else Gen.frequency(
         (8, Gen.oneOf(m.keys.toList)),

--- a/test/shared/src/test/scala/monocle/function/Data.scala
+++ b/test/shared/src/test/scala/monocle/function/Data.scala
@@ -3,19 +3,21 @@ package monocle.function
 import monocle._
 import org.scalacheck.{Cogen, Arbitrary}
 
-import cats.{Eq => Equal}
+import cats.{Eq => Equal, Order}
 import cats.data.NonEmptyList
 import cats.syntax.apply._
 
-case class MMap[K, V](map: Map[K, V])
+import scala.collection.immutable.SortedMap
+
+case class MMap[K, V](map: SortedMap[K, V])
 
 object MMap {
-  def toMap[K, V]: Iso[MMap[K, V], Map[K, V]] =
-    Iso[MMap[K, V], Map[K, V]](_.map)(MMap(_))
+  def toSortedMap[K, V]: Iso[MMap[K, V], SortedMap[K, V]] =
+    Iso[MMap[K, V], SortedMap[K, V]](_.map)(MMap(_))
 
   implicit def mmapEq[K, V]: Equal[MMap[K, V]] = Equal.fromUniversalEquals
-  implicit def mmapArb[K: Arbitrary, V: Arbitrary]: Arbitrary[MMap[K, V]] =
-    Arbitrary(Arbitrary.arbitrary[Map[K, V]].map(MMap(_)))
+  implicit def mmapArb[K: Arbitrary, V: Arbitrary](implicit ok: Order[K]): Arbitrary[MMap[K, V]] =
+    Arbitrary(Arbitrary.arbitrary[List[(K, V)]].map(kvs => MMap(SortedMap(kvs: _*)(ok.toOrdering))))
 }
 
 case class CNel(head: Char, tail: List[Char])

--- a/test/shared/src/test/scala/monocle/function/FilterIndexSpec.scala
+++ b/test/shared/src/test/scala/monocle/function/FilterIndexSpec.scala
@@ -1,12 +1,13 @@
 package monocle.function
 
+import cats.Order
 import monocle.MonocleSuite
 import monocle.law.discipline.function.FilterIndexTests
 
 class FilterIndexSpec extends MonocleSuite {
 
-  implicit def mmapFilterIndex[K, V]: FilterIndex[MMap[K, V], K, V] =
-    FilterIndex.fromIso(MMap.toMap)
+  implicit def mmapFilterIndex[K: Order, V]: FilterIndex[MMap[K, V], K, V] =
+    FilterIndex.fromIso(MMap.toSortedMap)
 
   checkAll("fromIso", FilterIndexTests[MMap[Int, String], Int, String])
 

--- a/test/shared/src/test/scala/monocle/function/IndexSpec.scala
+++ b/test/shared/src/test/scala/monocle/function/IndexSpec.scala
@@ -1,11 +1,12 @@
 package monocle.function
 
+import cats.Order
 import monocle.MonocleSuite
 import monocle.law.discipline.function.IndexTests
 
 class IndexSpec extends MonocleSuite {
 
-  implicit def mmapIndex[K, V]: Index[MMap[K, V], K, V] = Index.fromIso(MMap.toMap)
+  implicit def mmapIndex[K: Order, V]: Index[MMap[K, V], K, V] = Index.fromIso(MMap.toSortedMap)
 
   checkAll("fromIso", IndexTests[MMap[Int, String], Int, String])
 

--- a/test/shared/src/test/scala/monocle/std/MapSpec.scala
+++ b/test/shared/src/test/scala/monocle/std/MapSpec.scala
@@ -2,12 +2,14 @@ package monocle.std
 
 import monocle.MonocleSuite
 import monocle.law.discipline.function._
+import scala.collection.immutable.SortedMap
 
 class MapSpec extends MonocleSuite {
-  checkAll("at Map", AtTests[Map[Int, String], Int, Option[String]])
-  // typelevel/cats#1831 Map probably does not respect Traverse law at the moment
-  // checkAll("each Map", EachTests[Map[Int, String], String])
-  checkAll("empty Map", EmptyTests[Map[Int, String]])
-  checkAll("index Map", IndexTests[Map[Int, String], Int, String])
-  checkAll("filterIndex Map", FilterIndexTests[Map[Int, Char], Int, Char])
+
+  checkAll("at SortedMap", AtTests[SortedMap[Int, String], Int, Option[String]])
+  // typelevel/cats#1831 SortedMap probably does not respect Traverse law at the moment
+  // checkAll("each SortedMap", EachTests[SortedMap[Int, String], String])
+  checkAll("empty SortedMap", EmptyTests[SortedMap[Int, String]])
+  checkAll("index SortedMap", IndexTests[SortedMap[Int, String], Int, String])
+  checkAll("filterIndex SortedMap", FilterIndexTests[SortedMap[Int, Char], Int, Char])
 }

--- a/test/shared/src/test/scala/other/MacroOutSideMonocleSpec.scala
+++ b/test/shared/src/test/scala/other/MacroOutSideMonocleSpec.scala
@@ -37,7 +37,7 @@ class MacroOutSideMonocleSpec extends MonocleSuite {
 
   implicit val exampleEq: Equal[Example] = Equal.fromUniversalEquals[Example]
   implicit val example2Eq: Equal[Example2] = Equal.fromUniversalEquals[Example2]
-  implicit def exampleTypeEq[A](implicit as: Equal[Option[A]]): Equal[ExampleType[A]] = as.on(_.as)
+  implicit def exampleTypeEq[A](implicit as: Equal[Option[A]]): Equal[ExampleType[A]] = Equal.by(_.as)
   implicit def example2TypeEq[A](implicit a: Equal[A], as: Equal[Option[A]]): Equal[Example2Type[A]] = Equal.instance((x, y) => a.eqv(x.a, y.a) && as.eqv(x.as, y.as))
   implicit val exampleObjEq: Equal[ExampleObject.type] = Equal.fromUniversalEquals[ExampleObject.type]
   implicit val emptyCaseEq: Equal[EmptyCase] = Equal.fromUniversalEquals[EmptyCase]


### PR DESCRIPTION
This updates Monocle to cats-1.0.0-RC1.

The only real change is `Map` → `SortedMap` everywhere, which is a hassle but is mostly mechanical. The other option would be to pull in alley-cats but personally I'd prefer to relegate those instances to a `monocle-alleycats` or something and keep the core lawful.

I deleted the aliased `IList` and `IMap` examples but left the rename imports like `{ Monoidal => Zip }`. If you'd like to get rid of these and other scalaz cruft I can do it here or in another PR.