### PR TITLE
Update to the latest travis_setup.sh for Scala Native

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,6 @@ matrix:
     jdk: oraclejdk8
     sudo: required
     before_install:
-    - curl https://raw.githubusercontent.com/scala-native/scala-native/21539aa97947f767afcd85b5c2fb3c0262b2d301/bin/travis_setup.sh | bash -
+    - curl https://raw.githubusercontent.com/scala-native/scala-native/master/scripts/travis_setup.sh | bash -
     script:
     - sbt ++$TRAVIS_SCALA_VERSION testNative/run


### PR DESCRIPTION
[Recent PR](https://github.com/scala-native/scala-native/pull/1195) changed the location of the travis setup script within a Scala Native repo. This PR updates travis build to point to the new location.