### PR TITLE
Added `coProductIso`/`coProductDisjunctionIso` and `GenericOptics`

### DIFF
--- a/example/src/test/scala/monocle/generic/CoproductExample.scala
+++ b/example/src/test/scala/monocle/generic/CoproductExample.scala
@@ -1,8 +1,11 @@
 package monocle.generic
 
+import monocle.Lens
+import monocle.macros.GenLens
 import monocle.MonocleSuite
 import shapeless.test.illTyped
 import shapeless.{:+:, CNil, Coproduct}
+import scalaz.{-\/, \/-}
 
 class CoproductExample extends MonocleSuite {
 
@@ -26,4 +29,46 @@ class CoproductExample extends MonocleSuite {
       illTyped("""coProductPrism[ISB, Float]""")
   }
 
+  test("coProductIso creates an Iso between a Coproduct and the sum of its parts") {
+    val i = Coproduct[ISB](3)
+    val s = Coproduct[ISB]("hello")
+    val b = Coproduct[ISB](true)
+
+    coProductIso[ISB].apply.get(i) shouldEqual Left(3)
+    coProductIso[ISB].apply.get(s) shouldEqual Right(Left("hello"))
+    coProductIso[ISB].apply.get(b) shouldEqual Right(Right(true))
+
+    coProductIso[ISB].apply.reverseGet(Left(3)) shouldEqual i
+    coProductIso[ISB].apply.reverseGet(Right(Left("hello"))) shouldEqual s
+    coProductIso[ISB].apply.reverseGet(Right(Right(true))) shouldEqual b
+  }
+
+  test("coProductDisjunctionIso creates an Iso between a Coproduct and the sum of its parts") {
+    val i = Coproduct[ISB](3)
+    val s = Coproduct[ISB]("hello")
+    val b = Coproduct[ISB](true)
+
+    coProductDisjunctionIso[ISB].apply.get(i) shouldEqual -\/(3)
+    coProductDisjunctionIso[ISB].apply.get(s) shouldEqual \/-(-\/("hello"))
+    coProductDisjunctionIso[ISB].apply.get(b) shouldEqual \/-(\/-(true))
+
+    coProductDisjunctionIso[ISB].apply.reverseGet(-\/(3)) shouldEqual i
+    coProductDisjunctionIso[ISB].apply.reverseGet(\/-(-\/("hello"))) shouldEqual s
+    coProductDisjunctionIso[ISB].apply.reverseGet(\/-(\/-(true))) shouldEqual b
+  }
+
+  test("coProductDisjunctionIso can be composed with toGeneric") {
+    sealed trait X
+    case class A(a: String) extends X
+    case class B(b: String) extends X
+    case class C(c: String) extends X
+
+    val lens: Lens[X, String] =
+      toGeneric[X] composeIso coProductDisjunctionIso.apply composeLens
+        (GenLens[A](_.a) choice (GenLens[B](_.b) choice GenLens[C](_.c)))
+
+    lens.get(A("a")) shouldEqual "a"
+    lens.get(B("b")) shouldEqual "b"
+    lens.get(C("c")) shouldEqual "c"
+  }
 }

--- a/generic/shared/src/main/scala/monocle/generic/All.scala
+++ b/generic/shared/src/main/scala/monocle/generic/All.scala
@@ -7,3 +7,4 @@ trait GenericInstances
   with    HListInstances
   with    ProductOptics
   with    TupleNInstances
+  with    GenericOptics

--- a/generic/shared/src/main/scala/monocle/generic/CoProduct.scala
+++ b/generic/shared/src/main/scala/monocle/generic/CoProduct.scala
@@ -2,15 +2,15 @@ package monocle.generic
 
 import monocle.{Iso, Prism}
 import monocle.generic.internal.{CoproductToDisjunction, DisjunctionToCoproduct}
-import shapeless.Coproduct
+import shapeless.{Coproduct, Generic}
 import shapeless.ops.coproduct.{CoproductToEither, EitherToCoproduct, Inject, Selector}
-import scalaz.{\/}
+import scalaz.\/
 
 object coproduct extends CoProductInstances
 
 
 trait CoProductInstances {
-  
+
   def coProductPrism[C <: Coproduct, A](implicit evInject: Inject[C, A], evSelector: Selector[C, A]): Prism[C, A] =
     Prism[C, A](evSelector.apply(_))(evInject.apply)
 
@@ -19,18 +19,42 @@ trait CoProductInstances {
     * {{{
     *   type ISB = Int :+: String :+: Boolean :+: CNil
     *
-    *   val iso: Iso[ISB, Either[Int, Either[String, Boolean]]] = coProductIso[ISB].apply
+    *   val iso: Iso[ISB, Either[Int, Either[String, Boolean]]] = coProductEitherIso[ISB].apply
     * }}}
     */
-  def coProductIso[S <: Coproduct]: GenCoProductIso[S] = new GenCoProductIso[S]
+  def coProductEitherIso[S <: Coproduct]: GenCoProductEitherIso[S] = new GenCoProductEitherIso
 
-  class GenCoProductIso[S <: Coproduct] {
+  class GenCoProductEitherIso[S <: Coproduct] {
     def apply[L, R](implicit
                     coproductToEither: CoproductToEither.Aux[S, Either[L, R]],
                     eitherToCoproduct: EitherToCoproduct.Aux[L, R, S]
                    ): Iso[S, Either[L, R]] =
       Iso(coproductToEither.apply)(eitherToCoproduct.apply)
   }
+
+
+  /** An isomorphism between a sum type [[S]] (e.g. a sealed trait) and the sum of its parts.
+    *
+    * {{{
+    *   sealed trait S
+    *   case class A(name: String) extends S
+    *   case class B(name: String) extends S
+    *   case class C(otherName: String) extends S
+    *
+    *   val iso: Iso[S, Either[A, Either[B, C]]] = coProductToEither[S].apply
+    * }}}
+    */
+  def coProductToEither[S]: GenCoProductToEither[S] = new GenCoProductToEither
+
+  class GenCoProductToEither[S] {
+    def apply[C <: Coproduct, L, R](implicit
+                                    ev: Generic.Aux[S, C],
+                                    coproductToEither: CoproductToEither.Aux[C, Either[L, R]],
+                                    eitherToCoproduct: EitherToCoproduct.Aux[L, R, C]
+                                   ): Iso[S, Either[L, R]] =
+      generic.toGeneric[S] composeIso coProductEitherIso.apply
+  }
+
 
   /** An isomorphism between a coproduct [[S]] and the sum of its parts.
     *
@@ -40,7 +64,7 @@ trait CoProductInstances {
     *   val iso: Iso[ISB, Int \/ (String \/ Boolean)] = coProductDisjunctionIso[ISB].apply
     * }}}
     */
-  def coProductDisjunctionIso[S <: Coproduct]: GenCoProductDisjunctionIso[S] = new GenCoProductDisjunctionIso[S]
+  def coProductDisjunctionIso[S <: Coproduct]: GenCoProductDisjunctionIso[S] = new GenCoProductDisjunctionIso
 
   class GenCoProductDisjunctionIso[S <: Coproduct] {
     def apply[L, R](implicit
@@ -48,5 +72,27 @@ trait CoProductInstances {
                     disjunctionToCoproduct: DisjunctionToCoproduct.Aux[L, R, S]
                    ): Iso[S, L \/ R] =
       Iso(coproductToDisjunction.apply)(disjunctionToCoproduct.apply)
+  }
+
+  /** An isomorphism between a sum type [[S]] (e.g. a sealed trait) and the sum of its parts.
+    *
+    * {{{
+    *   sealed trait S
+    *   case class A(name: String) extends S
+    *   case class B(name: String) extends S
+    *   case class C(otherName: String) extends S
+    *
+    *   val iso: Iso[S, A \/ (B \/ C)] = coProductToDisjunction[S].apply
+    * }}}
+    */
+  def coProductToDisjunction[S]: GenCoProductToDisjunction[S] = new GenCoProductToDisjunction
+
+  class GenCoProductToDisjunction[S] {
+    def apply[C <: Coproduct, L, R](implicit
+                                    ev: Generic.Aux[S, C],
+                                    coproductToDisjunction: CoproductToDisjunction.Aux[C, L \/ R],
+                                    disjunctionToCoproduct: DisjunctionToCoproduct.Aux[L, R, C]
+                                   ): Iso[S, L \/ R] =
+      generic.toGeneric[S] composeIso coProductDisjunctionIso.apply
   }
 }

--- a/generic/shared/src/main/scala/monocle/generic/CoProduct.scala
+++ b/generic/shared/src/main/scala/monocle/generic/CoProduct.scala
@@ -1,8 +1,10 @@
 package monocle.generic
 
-import monocle.Prism
+import monocle.{Iso, Prism}
+import monocle.generic.internal.{CoproductToDisjunction, DisjunctionToCoproduct}
 import shapeless.Coproduct
-import shapeless.ops.coproduct.{Inject, Selector}
+import shapeless.ops.coproduct.{CoproductToEither, EitherToCoproduct, Inject, Selector}
+import scalaz.{\/}
 
 object coproduct extends CoProductInstances
 
@@ -11,6 +13,40 @@ trait CoProductInstances {
   
   def coProductPrism[C <: Coproduct, A](implicit evInject: Inject[C, A], evSelector: Selector[C, A]): Prism[C, A] =
     Prism[C, A](evSelector.apply(_))(evInject.apply)
-  
 
+  /** An isomorphism between a coproduct [[S]] and the sum of its parts.
+    *
+    * {{{
+    *   type ISB = Int :+: String :+: Boolean :+: CNil
+    *
+    *   val iso: Iso[ISB, Either[Int, Either[String, Boolean]]] = coProductIso[ISB].apply
+    * }}}
+    */
+  def coProductIso[S <: Coproduct]: GenCoProductIso[S] = new GenCoProductIso[S]
+
+  class GenCoProductIso[S <: Coproduct] {
+    def apply[L, R](implicit
+                    coproductToEither: CoproductToEither.Aux[S, Either[L, R]],
+                    eitherToCoproduct: EitherToCoproduct.Aux[L, R, S]
+                   ): Iso[S, Either[L, R]] =
+      Iso(coproductToEither.apply)(eitherToCoproduct.apply)
+  }
+
+  /** An isomorphism between a coproduct [[S]] and the sum of its parts.
+    *
+    * {{{
+    *   type ISB = Int :+: String :+: Boolean :+: CNil
+    *
+    *   val iso: Iso[ISB, Int \/ (String \/ Boolean)] = coProductDisjunctionIso[ISB].apply
+    * }}}
+    */
+  def coProductDisjunctionIso[S <: Coproduct]: GenCoProductDisjunctionIso[S] = new GenCoProductDisjunctionIso[S]
+
+  class GenCoProductDisjunctionIso[S <: Coproduct] {
+    def apply[L, R](implicit
+                    coproductToDisjunction: CoproductToDisjunction.Aux[S, L \/ R],
+                    disjunctionToCoproduct: DisjunctionToCoproduct.Aux[L, R, S]
+                   ): Iso[S, L \/ R] =
+      Iso(coproductToDisjunction.apply)(disjunctionToCoproduct.apply)
+  }
 }

--- a/generic/shared/src/main/scala/monocle/generic/Generic.scala
+++ b/generic/shared/src/main/scala/monocle/generic/Generic.scala
@@ -1,0 +1,13 @@
+package monocle.generic
+
+import monocle.Iso
+import shapeless.Generic
+
+object generic extends GenericOptics
+
+trait GenericOptics {
+
+  /** An isomorphism between a type [[S]] and its generic representation. */
+  def toGeneric[S](implicit S: Generic[S]): Iso[S, S.Repr] =
+    Iso[S, S.Repr](S.to(_))(S.from(_))
+}

--- a/generic/shared/src/main/scala/monocle/generic/internal/CoproductToDisjunction.scala
+++ b/generic/shared/src/main/scala/monocle/generic/internal/CoproductToDisjunction.scala
@@ -1,0 +1,35 @@
+package monocle.generic.internal
+
+import scalaz.{\/, -\/, \/-}
+import shapeless._
+
+/**
+  * Typeclass converting a [[Coproduct]] to an [[\/]].
+  *
+  * Based on [[shapeless.ops.coproduct.CoproductToEither]]:
+  * https://github.com/milessabin/shapeless/blob/shapeless-2.3.3-scala-2.13.0-M4/core/src/main/scala/shapeless/ops/coproduct.scala#L1275-L1303
+  */
+sealed trait CoproductToDisjunction[C <: Coproduct] extends DepFn1[C] with Serializable
+
+object CoproductToDisjunction {
+  type Aux[In <: Coproduct, Out0] = CoproductToDisjunction[In] { type Out = Out0 }
+
+  implicit def baseToEither[L, R]: CoproductToDisjunction.Aux[L :+: R :+: CNil, L \/ R] = new CoproductToDisjunction[L :+: R :+: CNil] {
+    type Out = L \/ R
+    def apply(t: L :+: R :+: CNil): L \/ R = t match {
+      case Inl(l)         => -\/(l)
+      case Inr(Inl(r))    => \/-(r)
+      case Inr(Inr(cnil)) => cnil.impossible
+    }
+  }
+
+  implicit def cconsToEither[L, R <: Coproduct, Out0](implicit
+    evR: CoproductToDisjunction.Aux[R, Out0]
+  ): CoproductToDisjunction.Aux[L :+: R, L \/ Out0] = new CoproductToDisjunction[L :+: R] {
+    type Out = L \/ Out0
+    def apply(t: L :+: R): L \/ Out0 = t match {
+      case Inl(l) => -\/(l)
+      case Inr(r) => \/-(evR(r))
+    }
+  }
+}

--- a/generic/shared/src/main/scala/monocle/generic/internal/DisjunctionToCoproduct.scala
+++ b/generic/shared/src/main/scala/monocle/generic/internal/DisjunctionToCoproduct.scala
@@ -1,0 +1,37 @@
+package monocle.generic.internal
+
+import scalaz.{\/, -\/, \/-}
+import shapeless._
+
+/**
+  * Typeclass converting an [[Either]] to a [[\/]].
+  *
+  * Based on [[shapeless.ops.coproduct.EitherToCoproduct]]:
+  * https://github.com/milessabin/shapeless/blob/shapeless-2.3.3-scala-2.13.0-M4/core/src/main/scala/shapeless/ops/coproduct.scala#L1305-L1335
+  */
+sealed trait DisjunctionToCoproduct[L, R] extends DepFn1[L \/ R] with Serializable { type Out <: Coproduct }
+
+object DisjunctionToCoproduct extends DisjunctionToCoproductLowPrio {
+  type Aux[L, R, Out0 <: Coproduct] = DisjunctionToCoproduct[L, R] { type Out = Out0 }
+
+  implicit def econsDisjunctionToCoproduct[L, RL, RR, Out0 <: Coproduct](implicit
+    evR: DisjunctionToCoproduct.Aux[RL, RR, Out0]
+  ): DisjunctionToCoproduct.Aux[L, RL \/ RR, L :+: Out0] = new DisjunctionToCoproduct[L, RL \/ RR] {
+    type Out = L :+: Out0
+    def apply(t: L \/ (RL \/ RR)): L :+: Out0 = t match {
+      case -\/(l) => Inl(l)
+      case \/-(r) => Inr(evR(r))
+    }
+  }
+}
+
+trait DisjunctionToCoproductLowPrio {
+  implicit def baseDisjunctionToCoproduct[L, R]: DisjunctionToCoproduct.Aux[L, R, L :+: R :+: CNil] = new DisjunctionToCoproduct[L, R] {
+    type Out = L :+: R :+: CNil
+
+    def apply(t: L \/ R): L :+: R :+: CNil = t match {
+      case -\/(l) => Inl(l)
+      case \/-(r) => Coproduct[L :+: R :+: CNil](r)
+    }
+  }
+}

--- a/test/shared/src/test/scala/monocle/generic/CoproductSpec.scala
+++ b/test/shared/src/test/scala/monocle/generic/CoproductSpec.scala
@@ -3,7 +3,7 @@ package monocle.generic
 import monocle.MonocleSuite
 import monocle.law.discipline.{PrismTests, IsoTests}
 import org.scalacheck.Arbitrary._
-import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.{Arbitrary, Cogen, Gen}
 import shapeless.{:+:, CNil, Coproduct, Inl, Inr}
 
 import scalaz.Equal
@@ -27,7 +27,26 @@ class CoproductSpec extends MonocleSuite {
 
   checkAll("Coproduct Prism", PrismTests(coProductPrism[IB, Boolean]))
 
-  checkAll("Coproduct Iso", IsoTests(coProductIso[IB].apply))
+  checkAll("Coproduct Either Iso", IsoTests(coProductEitherIso[IB].apply))
 
   checkAll("Coproduct Disjunction Iso", IsoTests(coProductDisjunctionIso[IB].apply))
+
+  sealed trait S
+  case class A() extends S
+  case object B extends S
+
+  implicit val sArbitrary = Arbitrary[S](Gen.oneOf(A(), B))
+  implicit val sEqual = Equal.equal[S](_ == _)
+
+  implicit val aArb: Arbitrary[A] = Arbitrary(A())
+  implicit val aEq: Equal[A]      = Equal.equal(_ == _)
+  implicit val aCogen: Cogen[A]   = Cogen(_ => 1)
+
+  implicit val bArb: Arbitrary[B.type] = Arbitrary(B)
+  implicit val bEq: Equal[B.type]      = Equal.equal(_ == _)
+  implicit val bCogen: Cogen[B.type]   = Cogen(_ => 2)
+
+  checkAll("Coproduct To Either", IsoTests(coProductToEither[S].apply))
+
+  checkAll("Coproduct To Disjunction", IsoTests(coProductToDisjunction[S].apply))
 }

--- a/test/shared/src/test/scala/monocle/generic/CoproductSpec.scala
+++ b/test/shared/src/test/scala/monocle/generic/CoproductSpec.scala
@@ -1,7 +1,7 @@
 package monocle.generic
 
 import monocle.MonocleSuite
-import monocle.law.discipline.PrismTests
+import monocle.law.discipline.{PrismTests, IsoTests}
 import org.scalacheck.Arbitrary._
 import org.scalacheck.{Arbitrary, Gen}
 import shapeless.{:+:, CNil, Coproduct, Inl, Inr}
@@ -27,4 +27,7 @@ class CoproductSpec extends MonocleSuite {
 
   checkAll("Coproduct Prism", PrismTests(coProductPrism[IB, Boolean]))
 
+  checkAll("Coproduct Iso", IsoTests(coProductIso[IB].apply))
+
+  checkAll("Coproduct Disjunction Iso", IsoTests(coProductDisjunctionIso[IB].apply))
 }


### PR DESCRIPTION
As discussed in the gitter channel, this PR adds an isomorphism between sum types (`shapeless.Coproduct`) and the disjunction of their parts.

If we have the following coproduct:

```scala
type ISB = Int :+: String :+: Boolean :+: CNil
```

We can use `coProductIso`/`coProductDisjunctionIso` to obtain the following isomorphisms:

```scala
val iso: Iso[ISB, Either[Int, Either[String, Boolean]]] = coProductIso[ISB].apply

val iso: Iso[ISB, Int \/ (String \/ Boolean)] = coProductDisjunctionIso[ISB].apply
```

## Use case

One use case where this is useful, is when every case class that extends a sealed trait has a common field, and you want to zoom in on it.

```scala
sealed trait X
case class A(name: String) extends X
case class B(name: String) extends X
case class C(name: String) extends X

val lens: Lens[X, String] =
  toGeneric[X] composeIso coProductDisjunctionIso.apply composeLens
    (GenLens[A](_.name) choice (GenLens[B](_.name) choice GenLens[C](_.name)))
```

## Notes

* `shapeless` gives us `CoproductToEither`/`EitherToCoproduct`. In order to be able to convert coproducts to scalaz's disjunction, I had to create two similar typeclasses in the `internal` package: `CoproductToDisjunction`/`DisjunctionToCoproduct`.
* I suggest that `monocle.generic.HListInstances.toHList` be deprecated, in favour of `monocle.generic.GenericIso.toGeneric` introduced in this PR.
* `CoproductToDisjunction` gives us a `\/` nested to the right, e.g. `A \/ (B (C \/ D))`. In the last code sample above, the user has to compose the lenses accordingly, e.g. `lensA choice (lensB choice (lensC choice lensD))`. The same thing happens if you use scalaz's `Choice.|||` operator. What are the owner's/maintainers' thoughts on adding a right-associative version of `|||` to make this composition a bit easier?

