### PR TITLE
Add optics for `cats.data.Chain` / `NonEmptyChain`

### DIFF
--- a/core/shared/src/main/scala/monocle/function/Cons.scala
+++ b/core/shared/src/main/scala/monocle/function/Cons.scala
@@ -73,4 +73,15 @@ object Cons extends ConsFunctions {
       case x +: xs  => Some((x, xs))
     }{ case (a, s) => a +: s }
   }
+
+  /************************************************************************************************/
+  /** Cats instances                                                                              */
+  /************************************************************************************************/
+  import cats.data.Chain
+
+  implicit def chainCons[A]: Cons[Chain[A], A] = new Cons[Chain[A], A]{
+    val cons = Prism[Chain[A], (A, Chain[A])](_.uncons) {
+      case (a, s) => s.prepend(a)
+    }
+  }
 }

--- a/core/shared/src/main/scala/monocle/function/Cons1.scala
+++ b/core/shared/src/main/scala/monocle/function/Cons1.scala
@@ -72,10 +72,10 @@ object Cons1 extends Cons1Functions {
   }
 
   /************************************************************************************************/
-  /** Cats instances                                                                            */
+  /** Cats instances                                                                              */
   /************************************************************************************************/
   import cats.Now
-  import cats.data.{NonEmptyList, NonEmptyVector, OneAnd}
+  import cats.data.{Chain, NonEmptyChain, NonEmptyList, NonEmptyVector, OneAnd}
   import cats.free.Cofree
   import scala.{List => IList, Vector => IVector}
 
@@ -89,6 +89,12 @@ object Cons1 extends Cons1Functions {
         * interested in using the `head` */
       override def head: Lens[Cofree[S, A], A] =
       Lens((c: Cofree[S, A]) => c.head)(h => c => Cofree(h, c.tail))
+    }
+
+  implicit def necCons1[A]: Cons1[NonEmptyChain[A], A, Chain[A]] =
+    new Cons1[NonEmptyChain[A],A,Chain[A]]{
+      val cons1: Iso[NonEmptyChain[A], (A, Chain[A])] =
+        Iso((nec: NonEmptyChain[A]) => (nec.head,nec.tail)){case (h,t) => NonEmptyChain.fromChainPrepend(h, t)}
     }
 
   implicit def nelCons1[A]: Cons1[NonEmptyList[A], A, IList[A]] =

--- a/core/shared/src/main/scala/monocle/function/Each.scala
+++ b/core/shared/src/main/scala/monocle/function/Each.scala
@@ -96,10 +96,14 @@ object Each extends EachFunctions {
   /************************************************************************************************/
   /** Cats instances                                                                            */
   /************************************************************************************************/
-  import cats.data.{NonEmptyList, NonEmptyVector, OneAnd, Validated => Validation}
+  import cats.data.{Chain, NonEmptyChain, NonEmptyList, NonEmptyVector, OneAnd, Validated => Validation}
   import cats.free.Cofree
 
   implicit def cofreeEach[S[_]: Traverse, A]: Each[Cofree[S, A], A] = fromTraverse[Cofree[S, ?], A]
+
+  implicit def chainEach[A]: Each[Chain[A], A] = fromTraverse
+
+  implicit def necEach[A]: Each[NonEmptyChain[A], A] = fromTraverse
 
   implicit def nelEach[A]: Each[NonEmptyList[A], A] = fromTraverse
 

--- a/core/shared/src/main/scala/monocle/function/Empty.scala
+++ b/core/shared/src/main/scala/monocle/function/Empty.scala
@@ -69,4 +69,13 @@ object Empty extends EmptyFunctions {
   implicit def vectorEmpty[A]: Empty[Vector[A]] = new Empty[Vector[A]] {
     val empty = Prism[Vector[A], Unit](v => if(v.isEmpty) Some(()) else None)(_ => Vector.empty)
   }
+
+  /************************************************************************************************/
+  /** Cats instances                                                                              */
+  /************************************************************************************************/
+  import cats.data.Chain
+
+  implicit def chainEmpty[A]: Empty[Chain[A]] = new Empty[Chain[A]] {
+    val empty = Prism[Chain[A], Unit](l => if(l.isEmpty) Some(()) else None)(_ => Chain.empty)
+  }
 }

--- a/core/shared/src/main/scala/monocle/function/FilterIndex.scala
+++ b/core/shared/src/main/scala/monocle/function/FilterIndex.scala
@@ -77,7 +77,13 @@ object FilterIndex extends FilterIndexFunctions {
   /************************************************************************************************/
   /** Cats instances                                                                            */
   /************************************************************************************************/
-  import cats.data.{NonEmptyList, NonEmptyVector}
+  import cats.data.{Chain, NonEmptyChain, NonEmptyList, NonEmptyVector}
+
+  implicit def chainFilterIndex[A]: FilterIndex[Chain[A], Int, A] =
+    fromTraverse(_.zipWithIndex)
+
+  implicit def necFilterIndex[A]: FilterIndex[NonEmptyChain[A], Int, A] =
+    fromTraverse(_.zipWithIndex)
 
   implicit def nelFilterIndex[A]: FilterIndex[NonEmptyList[A], Int, A] =
     fromTraverse(_.zipWithIndex)

--- a/core/shared/src/main/scala/monocle/function/Plated.scala
+++ b/core/shared/src/main/scala/monocle/function/Plated.scala
@@ -132,7 +132,18 @@ object Plated extends PlatedFunctions {
   /** Cats instances                                                                            */
   /************************************************************************************************/
   import cats.Now
+  import cats.data.Chain
   import cats.free.{Cofree, Free}
+
+  implicit def chainPlated[A]: Plated[Chain[A]] = new Plated[Chain[A]] {
+    val plate: Traversal[Chain[A], Chain[A]] = new Traversal[Chain[A], Chain[A]] {
+      def modifyF[F[_] : Applicative](f: Chain[A] => F[Chain[A]])(s: Chain[A]): F[Chain[A]] =
+        s.uncons match {
+          case Some((x, xs)) => Applicative[F].map(f(xs))(_.prepend(x))
+          case None          => Applicative[F].pure(Chain.empty)
+        }
+    }
+  }
 
   implicit def cofreePlated[S[_]: Traverse, A]: Plated[Cofree[S, A]] = new Plated[Cofree[S, A]] {
     val plate: Traversal[Cofree[S, A], Cofree[S, A]] = new Traversal[Cofree[S, A], Cofree[S, A]] {

--- a/core/shared/src/main/scala/monocle/function/Reverse.scala
+++ b/core/shared/src/main/scala/monocle/function/Reverse.scala
@@ -68,7 +68,13 @@ object Reverse extends ReverseFunctions {
   /************************************************************************************************/
   /** Cats instances                                                                            */
   /************************************************************************************************/
-  import cats.data.{NonEmptyList, NonEmptyVector}
+  import cats.data.{Chain, NonEmptyChain, NonEmptyList, NonEmptyVector}
+
+  implicit def chainReverse[A]: Reverse[Chain[A], Chain[A]] =
+    fromReverseFunction(_.reverse)
+
+  implicit def necReverse[A]: Reverse[NonEmptyChain[A], NonEmptyChain[A]] =
+    fromReverseFunction(_.reverse)
 
   implicit def nelReverse[A]: Reverse[NonEmptyList[A], NonEmptyList[A]] =
     fromReverseFunction(_.reverse)

--- a/core/shared/src/main/scala/monocle/function/Snoc1.scala
+++ b/core/shared/src/main/scala/monocle/function/Snoc1.scala
@@ -66,8 +66,21 @@ object Snoc1 extends Snoc1Functions {
   /************************************************************************************************/
   /** Cats instances                                                                            */
   /************************************************************************************************/
-  import cats.data.{NonEmptyList, NonEmptyVector}
+  import cats.data.{Chain, NonEmptyChain, NonEmptyList, NonEmptyVector}
   import scala.{List => IList, Vector => IVector}
+
+  implicit def necSnoc1[A]:Snoc1[NonEmptyChain[A], Chain[A], A] = new Snoc1[NonEmptyChain[A], Chain[A], A] {
+    val snoc1: Iso[NonEmptyChain[A], (Chain[A], A)] =
+      Iso {
+        nec: NonEmptyChain[A] =>
+          Snoc.chainSnoc.snoc.getOption(nec.toChain) match {
+            case Some(tuple) => tuple
+            case None        => (nec.tail, nec.head)
+          }
+      } {
+        case (c, a) => NonEmptyChain.fromChainAppend(c, a)
+      }
+  }
 
   implicit def nelSnoc1[A]:Snoc1[NonEmptyList[A], IList[A], A] = new Snoc1[NonEmptyList[A], IList[A], A]{
     val snoc1: Iso[NonEmptyList[A], (IList[A], A)] =

--- a/core/shared/src/main/scala/monocle/std/All.scala
+++ b/core/shared/src/main/scala/monocle/std/All.scala
@@ -19,9 +19,9 @@ trait StdInstances
   with    Tuple1Optics
   with    TryOptics
   // Cats Instances
+  with    ChainOptics
   with    CofreeOptics
   with    TheseOptics
-  with    ChainOptics
   with    NonEmptyChainOptics
   with    NonEmptyListOptics
   with    NonEmptyVectorOptics

--- a/core/shared/src/main/scala/monocle/std/All.scala
+++ b/core/shared/src/main/scala/monocle/std/All.scala
@@ -21,6 +21,8 @@ trait StdInstances
   // Cats Instances
   with    CofreeOptics
   with    TheseOptics
+  with    ChainOptics
+  with    NonEmptyChainOptics
   with    NonEmptyListOptics
   with    NonEmptyVectorOptics
   with    ValidationOptics

--- a/core/shared/src/main/scala/monocle/std/Chain.scala
+++ b/core/shared/src/main/scala/monocle/std/Chain.scala
@@ -1,0 +1,21 @@
+package monocle.std
+
+import cats.data.Chain
+import monocle.{Iso, PIso}
+
+object chain extends ChainOptics
+
+trait ChainOptics {
+  def pChainToList[A, B]: PIso[Chain[A], Chain[B], List[A], List[B]] =
+    PIso[Chain[A], Chain[B], List[A], List[B]](_.toList)(Chain.fromSeq)
+
+  def chainToList[A]: Iso[Chain[A], List[A]] =
+    pChainToList[A, A]
+
+
+  def pChainToVector[A, B]: PIso[Chain[A], Chain[B], Vector[A], Vector[B]] =
+    PIso[Chain[A], Chain[B], Vector[A], Vector[B]](_.toVector)(Chain.fromSeq)
+
+  def chainToVector[A]: Iso[Chain[A], Vector[A]] =
+    pChainToVector[A, A]
+}

--- a/core/shared/src/main/scala/monocle/std/NonEmptyChain.scala
+++ b/core/shared/src/main/scala/monocle/std/NonEmptyChain.scala
@@ -1,0 +1,31 @@
+package monocle.std
+
+import monocle.{Iso, PIso, PPrism, Prism}
+import cats.data.{Chain, NonEmptyChain, OneAnd}
+
+object nec extends NonEmptyChainOptics
+
+trait NonEmptyChainOptics {
+
+  final def pNecToOneAnd[A, B]: PIso[NonEmptyChain[A], NonEmptyChain[B], OneAnd[Chain,A], OneAnd[Chain,B]] =
+    PIso((nec: NonEmptyChain[A])    => OneAnd[Chain,A](nec.head, nec.tail))(
+      (oneAnd: OneAnd[Chain, B]) => NonEmptyChain.fromChainPrepend(oneAnd.head, oneAnd.tail))
+
+  final def necToOneAnd[A]: Iso[NonEmptyChain[A], OneAnd[Chain,A]] =
+    pNecToOneAnd[A, A]
+
+  final def pOptNecToChain[A, B]: PIso[Option[NonEmptyChain[A]], Option[NonEmptyChain[B]], Chain[A], Chain[B]] =
+    PIso[Option[NonEmptyChain[A]], Option[NonEmptyChain[B]], Chain[A], Chain[B]](_.fold(Chain.empty[A])(_.toChain))(
+      NonEmptyChain.fromChain
+    )
+
+  final def optNecToChain[A]: Iso[Option[NonEmptyChain[A]], Chain[A]] =
+    pOptNecToChain[A, A]
+
+  final def pChainToNec[A, B]: PPrism[Chain[A], Chain[B], NonEmptyChain[A], NonEmptyChain[B]] =
+    PPrism((v: Chain[A]) => NonEmptyChain.fromChain[A](v).toRight(Chain.empty[B]))((nec: NonEmptyChain[B]) => nec.toChain)
+
+  final def chainToNec[A]: Prism[Chain[A], NonEmptyChain[A]] =
+    pChainToNec[A, A]
+
+}

--- a/test/shared/src/test/scala/monocle/std/ChainSpec.scala
+++ b/test/shared/src/test/scala/monocle/std/ChainSpec.scala
@@ -1,0 +1,24 @@
+package monocle.std
+
+import cats.data.Chain
+import monocle.MonocleSuite
+import monocle.function.Plated._
+import monocle.law.discipline.{IsoTests, TraversalTests}
+import monocle.law.discipline.function._
+
+class ChainSpec extends MonocleSuite {
+  import cats.laws.discipline.arbitrary._
+
+  checkAll("chainToList", IsoTests(chainToList[Int]))
+  checkAll("chainToVector", IsoTests(chainToVector[Int]))
+
+  checkAll("reverse Chain", ReverseTests[Chain[Int]])
+  checkAll("empty Chain", EmptyTests[Chain[Int]])
+  checkAll("cons Chain", ConsTests[Chain[Int], Int])
+  checkAll("snoc Chain", SnocTests[Chain[Int], Int])
+  checkAll("each Chain", EachTests[Chain[Int], Int])
+  checkAll("index Chain", IndexTests[Chain[Int], Int, Int])
+  checkAll("filterIndex Chain", FilterIndexTests[Chain[Int], Int, Int])
+
+  checkAll("plated Chain", TraversalTests(plate[Chain[Int]]))
+}

--- a/test/shared/src/test/scala/monocle/std/CofreeSpec.scala
+++ b/test/shared/src/test/scala/monocle/std/CofreeSpec.scala
@@ -7,6 +7,8 @@ import monocle.law.discipline.function._
 import cats.free.Cofree
 
 class CofreeSpec extends MonocleSuite {
+   import cats.laws.discipline.arbitrary._
+
    checkAll("cofreeToStream", IsoTests(cofreeToStream[Int]))
    checkAll("cons1 cofree", Cons1Tests[Cofree[Option, Int], Int, Option[Cofree[Option, Int]]])
    checkAll("each cofree", EachTests[Cofree[Option, Int], Int])

--- a/test/shared/src/test/scala/monocle/std/NonEmptyChainSpec.scala
+++ b/test/shared/src/test/scala/monocle/std/NonEmptyChainSpec.scala
@@ -1,0 +1,22 @@
+package monocle.std
+
+import cats.data.{Chain, NonEmptyChain}
+import monocle.MonocleSuite
+import monocle.law.discipline.{IsoTests, PrismTests}
+import monocle.law.discipline.function._
+
+class NonEmptyChainSpec extends MonocleSuite {
+  import cats.laws.discipline.arbitrary._
+
+  checkAll("necToAndOne", IsoTests(necToOneAnd[Int]))
+  checkAll("optNecToChain", IsoTests(optNecToChain[Int]))
+  checkAll("chainToNec", PrismTests(chainToNec[Int]))
+
+  checkAll("each NonEmptyChain", EachTests[NonEmptyChain[Int], Int])
+  checkAll("index NonEmptyChain", IndexTests[NonEmptyChain[Int], Int, Int])
+  checkAll("filterIndex NonEmptyChain", FilterIndexTests[NonEmptyChain[Int], Int, Int])
+  checkAll("reverse NonEmptyChain", ReverseTests[NonEmptyChain[Int]])
+  checkAll("cons1 NonEmptyChain", Cons1Tests[NonEmptyChain[Int], Int, Chain[Int]])
+  checkAll("snoc1 NonEmptyChain", Snoc1Tests[NonEmptyChain[Int], Chain[Int], Int])
+}
+

--- a/test/shared/src/test/scala/monocle/std/NonEmptyListSpec.scala
+++ b/test/shared/src/test/scala/monocle/std/NonEmptyListSpec.scala
@@ -8,6 +8,8 @@ import cats.data.NonEmptyList
 import scala.{List => IList}
 
 class NonEmptyListSpec extends MonocleSuite {
+  import cats.laws.discipline.arbitrary._
+
   checkAll("nelToAndOne", IsoTests(nelToOneAnd[Int]))
   checkAll("optNelToList", IsoTests(optNelToList[Int]))
 

--- a/test/shared/src/test/scala/monocle/std/NonEmptyVectorSpec.scala
+++ b/test/shared/src/test/scala/monocle/std/NonEmptyVectorSpec.scala
@@ -8,6 +8,8 @@ import monocle.law.discipline.function._
 import scala.{Vector => IVector}
 
 class NonEmptyVectorSpec extends MonocleSuite {
+  import cats.laws.discipline.arbitrary._
+
   checkAll("nevToAndOne", IsoTests(nevToOneAnd[Int]))
   checkAll("optNevToVector", IsoTests(optNevToVector[Int]))
   checkAll("vectorToNev", PrismTests(vectorToNev[Int]))

--- a/test/shared/src/test/scala/monocle/std/OneAndSpec.scala
+++ b/test/shared/src/test/scala/monocle/std/OneAndSpec.scala
@@ -6,6 +6,8 @@ import monocle.law.discipline.function.{Cons1Tests, EachTests, IndexTests}
 import cats.data.OneAnd
 
 class OneAndSpec extends MonocleSuite {
+  import cats.laws.discipline.arbitrary._
+
   checkAll("each OneAnd", EachTests[OneAnd[List, Int], Int])
   checkAll("index OneAnd", IndexTests[OneAnd[List, Int], Int, Int])
   checkAll("cons1 OneAnd", Cons1Tests[OneAnd[List, Int], Int, List[Int]])

--- a/test/shared/src/test/scala/monocle/std/TheseSpec.scala
+++ b/test/shared/src/test/scala/monocle/std/TheseSpec.scala
@@ -4,5 +4,7 @@ import monocle.MonocleSuite
 import monocle.law.discipline.PrismTests
 
 class TheseSpec extends MonocleSuite {
+  import cats.laws.discipline.arbitrary._
+
   checkAll("These - Disjunction" , PrismTests(theseToDisjunction[Int, String]))
 }

--- a/test/shared/src/test/scala/monocle/std/ValidationSpec.scala
+++ b/test/shared/src/test/scala/monocle/std/ValidationSpec.scala
@@ -6,6 +6,8 @@ import monocle.law.discipline.function.{EachTests, PossibleTests}
 import cats.data.{Validated => Validation}
 
 class ValidationSpec extends MonocleSuite {
+  import cats.laws.discipline.arbitrary._
+
   checkAll("Validation is isomorphic to Disjunction", IsoTests(monocle.std.validation.validationToDisjunction[String, Int]))
   checkAll("success", PrismTests(monocle.std.validation.success[String, Int]))
   checkAll("failure", PrismTests(monocle.std.validation.failure[String, Int]))


### PR DESCRIPTION
`Chain` doesn't have methods like `drop` and `updated` like lists do, so some of these implementations are a bit more verbose.

Also: deleted instances for cats' data types from `TestInstances`, and used the pre-defined instances from `import cats.laws.discipline.arbitrary._` instead.

