### PR TITLE
Add missing function to State module (fixes #548)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_install:
 before_script:
   - sudo chmod +x /usr/local/bin/sbt
 install:
-  - rvm use 2.2.8 --install --fuzzy
+  - rvm use 2.4.0 --install --fuzzy
   - gem update --system
   - gem install sass
   - gem install jekyll -v 3.2.1

--- a/example/src/test/scala/monocle/state/StateExample.scala
+++ b/example/src/test/scala/monocle/state/StateExample.scala
@@ -1,6 +1,6 @@
 package monocle.state
 
-import monocle.{MonocleSuite, Optional, Getter}
+import monocle.{MonocleSuite, Optional, Setter, Getter}
 import monocle.macros.GenLens
 
 class StateExample extends MonocleSuite {
@@ -23,6 +23,50 @@ class StateExample extends MonocleSuite {
     } yield i
 
     getDoubleAge.run(p).value shouldEqual ((Person("John", 30), 60))
+  }
+
+  test("mod"){
+    val increment = for {
+      i <- _age mod (_ + 1)
+    } yield i
+
+    increment.run(p).value shouldEqual ((Person("John", 31), 31))
+  }
+
+  test("modo"){
+    val increment = for {
+      i <- _age modo (_ + 1)
+    } yield i
+
+    increment.run(p).value shouldEqual ((Person("John", 31), 30))
+  }
+
+  test("mod_"){
+    val increment = _age mod_ (_ + 1)
+
+    increment.run(p).value shouldEqual ((Person("John", 31), ()))
+  }
+
+  test("assign"){
+    val set20 = for {
+      i <- _age assign 20
+    } yield i
+
+    set20.run(p).value shouldEqual ((Person("John", 20), 20))
+  }
+
+  test("assigno"){
+    val set20 = for {
+      i <- _age assigno 20
+    } yield i
+
+    set20.run(p).value shouldEqual ((Person("John", 20), 30))
+  }
+
+  test("assign_"){
+    val set20 = _age assign_ 20
+
+    set20.run(p).value shouldEqual ((Person("John", 20), ()))
   }
 
   val _oldAge = Optional[Person, Int](p => if (p.age > 50) Some(p.age) else None){ a => _.copy(age = a) }
@@ -54,6 +98,140 @@ class StateExample extends MonocleSuite {
     val update = _oldAge extracts (_ * 2)
 
     update.run(oldPerson).value shouldEqual ((Person("John", 100), Some(200)))
+  }
+
+  test("mod for Optional (predicate is false)"){
+    val youngPerson = Person("John", 30)
+    val update = for {
+      i <- _oldAge mod (_ + 1)
+    } yield i
+
+    update.run(youngPerson).value shouldEqual ((Person("John", 30), None))
+  }
+
+  test("mod for Optional (predicate is true)"){
+    val oldPerson = Person("John", 100)
+    val update = for {
+      i <- _oldAge mod (_ + 1)
+    } yield i
+
+    update.run(oldPerson).value shouldEqual ((Person("John", 101), Some(101)))
+  }
+
+  test("modo for Optional (predicate is false)"){
+    val youngPerson = Person("John", 30)
+    val update = for {
+      i <- _oldAge modo (_ + 1)
+    } yield i
+
+    update.run(youngPerson).value shouldEqual ((Person("John", 30), None))
+  }
+
+  test("modo for Optional (predicate is true)"){
+    val oldPerson = Person("John", 100)
+    val update = for {
+      i <- _oldAge modo (_ + 1)
+    } yield i
+
+    update.run(oldPerson).value shouldEqual ((Person("John", 101), Some(100)))
+  }
+
+  test("modo for Optional (chaining modifications)"){
+    val oldCoolPerson = Person("Chris", 100)
+    val update = for {
+      _ <- _oldAge modo (_ + 1)
+      x <- _coolGuy modo (_.toLowerCase)
+    } yield x
+
+    update.run(oldCoolPerson).value shouldEqual ((Person("chris", 101), Some("Chris")))
+  }
+
+  test("modo for Optional (only some of the modifications are applied)"){
+    val oldCoolPerson = Person("Chris", 30)
+    val update = for {
+      _ <- _oldAge modo (_ + 1)
+      x <- _coolGuy modo (_.toLowerCase)
+    } yield x
+
+    update.run(oldCoolPerson).value shouldEqual ((Person("chris", 30), Some("Chris")))
+  }
+
+  test("mod_ for Optional (predicate is false)"){
+    val youngPerson = Person("John", 30)
+    val update = _oldAge mod_ (_ + 1)
+
+    update.run(youngPerson).value shouldEqual ((Person("John", 30), ()))
+  }
+
+  test("mod_ for Optional (predicate is true)"){
+    val oldPerson = Person("John", 100)
+    val update = _oldAge mod_ (_ + 1)
+
+    update.run(oldPerson).value shouldEqual ((Person("John", 101), ()))
+  }
+
+  test("assign for Optional (predicate is true)"){
+    val oldPerson = Person("John", 100)
+    val update = for {
+      i <- _oldAge assign 30
+    } yield i
+
+    update.run(oldPerson).value shouldEqual ((Person("John", 30), Some(30)))
+  }
+
+  test("assign for Optional (predicate is false)"){
+    val youngPerson = Person("John", 30)
+    val update = for {
+      i <- _oldAge assign 100
+    } yield i
+
+    update.run(youngPerson).value shouldEqual ((Person("John", 30), None))
+  }
+
+  test("assigno for Optional (predicate is true)"){
+    val oldPerson = Person("John", 100)
+    val update = for {
+      i <- _oldAge assigno 30
+    } yield i
+
+    update.run(oldPerson).value shouldEqual ((Person("John", 30), Some(100)))
+  }
+
+  test("assigno for Optional (predicate is false)"){
+    val youngPerson = Person("John", 30)
+    val update = for {
+      i <- _oldAge assigno 100
+    } yield i
+
+    update.run(youngPerson).value shouldEqual ((Person("John", 30), None))
+  }
+
+  test("assign_ for Optional (predicate is true)"){
+    val oldPerson = Person("John", 100)
+    val update = _oldAge assign_ 30
+
+    update.run(oldPerson).value shouldEqual ((Person("John", 30),()))
+  }
+
+  test("assign_ for Optional (predicate is false)"){
+    val youngPerson = Person("John", 30)
+    val update = _oldAge assign_ 100
+
+    update.run(youngPerson).value shouldEqual ((Person("John", 30), ()))
+  }
+
+  val _nameSet = Setter[Person, String](f => p => p.copy(name = f(p.name)))
+
+  test("mod_ for Setter"){
+    val toUpper = _nameSet mod_ (_.toUpperCase)
+
+    toUpper.run(p).value shouldEqual ((Person("JOHN", 30), ()))
+  }
+
+  test("assign_ for Setter"){
+    val toUpper = _nameSet assign_ ("Juan")
+
+    toUpper.run(p).value shouldEqual ((Person("Juan", 30), ()))
   }
 
   val _nameGet = Getter[Person, String](_.name)

--- a/state/shared/src/main/scala/monocle/state/All.scala
+++ b/state/shared/src/main/scala/monocle/state/All.scala
@@ -3,4 +3,5 @@ package monocle.state
 object all extends StateLensSyntax
   with StateOptionalSyntax
   with StateGetterSyntax
+  with StateSetterSyntax
   with ReaderGetterSyntax

--- a/state/shared/src/main/scala/monocle/state/StateLensSyntax.scala
+++ b/state/shared/src/main/scala/monocle/state/StateLensSyntax.scala
@@ -1,8 +1,8 @@
 package monocle.state
 
+import cats.{Eval, Now}
 import monocle.PLens
-
-import cats.data.State
+import cats.data.{IndexedStateT, State}
 
 trait StateLensSyntax {
   implicit def toStateLensOps[S, T, A, B](lens: PLens[S, T, A, B]): StateLensOps[S, T, A, B] =
@@ -25,4 +25,32 @@ final class StateLensOps[S, T, A, B](lens: PLens[S, T, A, B]) {
   /** extracts the value viewed through the lens and applies `f` over it */
   def extracts[B](f: A => B): State[S, B] =
     extract.map(f)
+
+  /** modify the value viewed through the lens and returns its *new* value */
+  def mod(f: A => B): IndexedStateT[Eval, S, T, B] =
+    IndexedStateT(s => {
+      val a = lens.get(s)
+      val b = f(a)
+      Now((lens.set(b)(s), b))
+    })
+
+  /** modify the value viewed through the lens and returns its *old* value */
+  def modo(f: A => B): IndexedStateT[Eval, S, T, A] =
+    toState.bimap(lens.modify(f), identity)
+
+  /** modify the value viewed through the lens and ignores both values */
+  def mod_(f: A => B): IndexedStateT[Eval, S, T, Unit] =
+    IndexedStateT(s => Now((lens.modify(f)(s), ())))
+
+  /** set the value viewed through the lens and returns its *new* value */
+  def assign(b: B): IndexedStateT[Eval, S, T, B] =
+    mod(_ => b)
+
+  /** set the value viewed through the lens and returns its *old* value */
+  def assigno(b: B): IndexedStateT[Eval, S, T, A] =
+    modo(_ => b)
+
+  /** set the value viewed through the lens and ignores both values */
+  def assign_(b: B): IndexedStateT[Eval, S, T, Unit] =
+    mod_(_ => b)
 }

--- a/state/shared/src/main/scala/monocle/state/StateOptionalSyntax.scala
+++ b/state/shared/src/main/scala/monocle/state/StateOptionalSyntax.scala
@@ -1,8 +1,8 @@
 package monocle.state
 
+import cats.{Eval, Now}
 import monocle.POptional
-
-import cats.data.State
+import cats.data.{IndexedStateT, State}
 
 trait StateOptionalSyntax {
   implicit def toStateOptionalOps[S, T, A, B](optional: POptional[S, T, A, B]): StateOptionalOps[S, T, A, B] =
@@ -25,4 +25,28 @@ final class StateOptionalOps[S, T, A, B](optional: POptional[S, T, A, B]) {
   /** extracts the value viewed through the optional and applies `f` over it */
   def extracts[B](f: A => B): State[S, Option[B]] =
     extract.map(_.map(f))
+
+  /** modify the value viewed through the Optional and return its *new* value, if there is one */
+  def mod(f: A => B): IndexedStateT[Eval, S, T, Option[B]] =
+    modo(f).map(_.map(f))
+
+  /** modify the value viewed through the Optional and return its *old* value, if there was one */
+  def modo(f: A => B): IndexedStateT[Eval, S, T, Option[A]] =
+    IndexedStateT(s => Now((optional.modify(f)(s), optional.getOption(s))))
+
+  /** modify the value viewed through the Optional and ignores both values */
+  def mod_(f: A => B): IndexedStateT[Eval, S, T, Unit] =
+    IndexedStateT(s => Now((optional.modify(f)(s), ())))
+
+  /** set the value viewed through the Optional and returns its *new* value */
+  def assign(b: B): IndexedStateT[Eval, S, T, Option[B]] =
+    mod(_ => b)
+
+  /** set the value viewed through the Optional and return its *old* value, if there was one */
+  def assigno(b: B): IndexedStateT[Eval, S, T, Option[A]] =
+    modo(_ => b)
+
+  /** set the value viewed through the Optional and ignores both values */
+  def assign_(b: B): IndexedStateT[Eval,S, T, Unit] =
+    mod_(_ => b)
 }

--- a/state/shared/src/main/scala/monocle/state/StateSetterSyntax.scala
+++ b/state/shared/src/main/scala/monocle/state/StateSetterSyntax.scala
@@ -1,0 +1,20 @@
+package monocle.state
+
+import cats.{Eval, Now}
+import monocle.PSetter
+import cats.data.IndexedStateT
+
+trait StateSetterSyntax {
+  implicit def toStateSetterOps[S, T, A, B](setter: PSetter[S, T, A, B]): StateSetterOps[S, T, A, B] =
+    new StateSetterOps[S, T, A, B](setter)
+}
+
+final class StateSetterOps[S, T, A, B](setter: PSetter[S, T, A, B]) {
+  /** modify the value referenced through the setter */
+  def mod_(f: A => B): IndexedStateT[Eval, S, T, Unit] =
+    IndexedStateT(s => Now((setter.modify(f)(s), ())))
+
+  /** set the value referenced through the setter */
+  def assign_(b: B): IndexedStateT[Eval, S, T, Unit] =
+    mod_(_ => b)
+}

--- a/test/shared/src/test/scala/monocle/MonocleSuite.scala
+++ b/test/shared/src/test/scala/monocle/MonocleSuite.scala
@@ -21,4 +21,5 @@ trait MonocleSuite extends FunSuite
                       with StateLensSyntax
                       with StateOptionalSyntax
                       with StateGetterSyntax
+                      with StateSetterSyntax
                       with ReaderGetterSyntax


### PR DESCRIPTION
The syntax can be simplified once https://github.com/typelevel/cats/issues/2686 if fixed

`StateTraversalSyntax` can be tested (therefore ported) once https://github.com/typelevel/cats/issues/2687 is fixed