### PR TITLE
Added `coProductIso`/`coProductDisjunctionIso` for cats version

### DIFF
--- a/example/src/test/scala/monocle/generic/CoproductExample.scala
+++ b/example/src/test/scala/monocle/generic/CoproductExample.scala
@@ -1,5 +1,7 @@
 package monocle.generic
 
+import monocle.Lens
+import monocle.macros.GenLens
 import monocle.MonocleSuite
 import shapeless.test.illTyped
 import shapeless.{:+:, CNil, Coproduct}
@@ -26,4 +28,76 @@ class CoproductExample extends MonocleSuite {
       illTyped("""coProductPrism[ISB, Float]""")
   }
 
+  test("coProductEitherIso creates an Iso between a Coproduct and the sum of its parts") {
+    val i = Coproduct[ISB](3)
+    val s = Coproduct[ISB]("hello")
+    val b = Coproduct[ISB](true)
+
+    coProductEitherIso[ISB].apply.get(i) shouldEqual Left(3)
+    coProductEitherIso[ISB].apply.get(s) shouldEqual Right(Left("hello"))
+    coProductEitherIso[ISB].apply.get(b) shouldEqual Right(Right(true))
+
+    coProductEitherIso[ISB].apply.reverseGet(Left(3)) shouldEqual i
+    coProductEitherIso[ISB].apply.reverseGet(Right(Left("hello"))) shouldEqual s
+    coProductEitherIso[ISB].apply.reverseGet(Right(Right(true))) shouldEqual b
+  }
+
+  test("coProductToEither creates an Iso between a sealed trait and the sum of its parts") {
+    sealed trait S
+    case class A(name: String) extends S
+    case class B(name: String) extends S
+    case class C(otherName: String) extends S
+
+    coProductToEither[S].apply.get(A("a")) shouldEqual Left(A("a"))
+    coProductToEither[S].apply.get(B("b")) shouldEqual Right(Left(B("b")))
+    coProductToEither[S].apply.get(C("c")) shouldEqual Right(Right(C("c")))
+
+    coProductToEither[S].apply.reverseGet(Left(A("a"))) shouldEqual A("a")
+    coProductToEither[S].apply.reverseGet(Right(Left(B("b")))) shouldEqual B("b")
+    coProductToEither[S].apply.reverseGet(Right(Right(C("c")))) shouldEqual C("c")
+  }
+
+  test("coProductDisjunctionIso creates an Iso between a Coproduct and the sum of its parts") {
+    val i = Coproduct[ISB](3)
+    val s = Coproduct[ISB]("hello")
+    val b = Coproduct[ISB](true)
+
+    coProductDisjunctionIso[ISB].apply.get(i) shouldEqual Left(3)
+    coProductDisjunctionIso[ISB].apply.get(s) shouldEqual Right(Left("hello"))
+    coProductDisjunctionIso[ISB].apply.get(b) shouldEqual Right(Right(true))
+
+    coProductDisjunctionIso[ISB].apply.reverseGet(Left(3)) shouldEqual i
+    coProductDisjunctionIso[ISB].apply.reverseGet(Right(Left("hello"))) shouldEqual s
+    coProductDisjunctionIso[ISB].apply.reverseGet(Right(Right(true))) shouldEqual b
+  }
+
+  test("coProductToDisjunction creates an Iso between a sealed trait and the sum of its parts") {
+    sealed trait S
+    case class A(name: String) extends S
+    case class B(name: String) extends S
+    case class C(otherName: String) extends S
+
+    coProductToDisjunction[S].apply.get(A("a")) shouldEqual Left(A("a"))
+    coProductToDisjunction[S].apply.get(B("b")) shouldEqual Right(Left(B("b")))
+    coProductToDisjunction[S].apply.get(C("c")) shouldEqual Right(Right(C("c")))
+
+    coProductToDisjunction[S].apply.reverseGet(Left(A("a"))) shouldEqual A("a")
+    coProductToDisjunction[S].apply.reverseGet(Right(Left(B("b")))) shouldEqual B("b")
+    coProductToDisjunction[S].apply.reverseGet(Right(Right(C("c")))) shouldEqual C("c")
+  }
+
+  test("coProductToDisjunction can be used to zoom in on a sealed trait's classes.") {
+    sealed trait S
+    case class A(name: String) extends S
+    case class B(name: String) extends S
+    case class C(otherName: String) extends S
+
+    val lens: Lens[S, String] =
+      coProductToDisjunction[S].apply composeLens
+        (GenLens[A](_.name) choice (GenLens[B](_.name) choice GenLens[C](_.otherName)))
+
+    lens.get(A("a")) shouldEqual "a"
+    lens.get(B("b")) shouldEqual "b"
+    lens.get(C("c")) shouldEqual "c"
+  }
 }

--- a/generic/shared/src/main/scala/monocle/generic/All.scala
+++ b/generic/shared/src/main/scala/monocle/generic/All.scala
@@ -7,3 +7,4 @@ trait GenericInstances
   with    HListInstances
   with    ProductOptics
   with    TupleNInstances
+  with    GenericOptics

--- a/generic/shared/src/main/scala/monocle/generic/CoProduct.scala
+++ b/generic/shared/src/main/scala/monocle/generic/CoProduct.scala
@@ -1,16 +1,99 @@
 package monocle.generic
 
-import monocle.Prism
-import shapeless.Coproduct
-import shapeless.ops.coproduct.{Inject, Selector}
+import monocle.{Iso, Prism}
+import monocle.generic.internal.{CoproductToDisjunction, DisjunctionToCoproduct}
+import shapeless.{Coproduct, Generic}
+import shapeless.ops.coproduct.{CoproductToEither, EitherToCoproduct, Inject, Selector}
+import scala.{Either => \/}
 
 object coproduct extends CoProductInstances
 
 
 trait CoProductInstances {
-  
+
   def coProductPrism[C <: Coproduct, A](implicit evInject: Inject[C, A], evSelector: Selector[C, A]): Prism[C, A] =
     Prism[C, A](evSelector.apply(_))(evInject.apply)
-  
 
+  /** An isomorphism between a coproduct [[S]] and the sum of its parts.
+    *
+    * {{{
+    *   type ISB = Int :+: String :+: Boolean :+: CNil
+    *
+    *   val iso: Iso[ISB, Either[Int, Either[String, Boolean]]] = coProductEitherIso[ISB].apply
+    * }}}
+    */
+  def coProductEitherIso[S <: Coproduct]: GenCoProductEitherIso[S] = new GenCoProductEitherIso
+
+  class GenCoProductEitherIso[S <: Coproduct] {
+    def apply[L, R](implicit
+                    coproductToEither: CoproductToEither.Aux[S, Either[L, R]],
+                    eitherToCoproduct: EitherToCoproduct.Aux[L, R, S]
+                   ): Iso[S, Either[L, R]] =
+      Iso(coproductToEither.apply)(eitherToCoproduct.apply)
+  }
+
+
+  /** An isomorphism between a sum type [[S]] (e.g. a sealed trait) and the sum of its parts.
+    *
+    * {{{
+    *   sealed trait S
+    *   case class A(name: String) extends S
+    *   case class B(name: String) extends S
+    *   case class C(otherName: String) extends S
+    *
+    *   val iso: Iso[S, Either[A, Either[B, C]]] = coProductToEither[S].apply
+    * }}}
+    */
+  def coProductToEither[S]: GenCoProductToEither[S] = new GenCoProductToEither
+
+  class GenCoProductToEither[S] {
+    def apply[C <: Coproduct, L, R](implicit
+                                    ev: Generic.Aux[S, C],
+                                    coproductToEither: CoproductToEither.Aux[C, Either[L, R]],
+                                    eitherToCoproduct: EitherToCoproduct.Aux[L, R, C]
+                                   ): Iso[S, Either[L, R]] =
+      generic.toGeneric[S] composeIso coProductEitherIso.apply
+  }
+
+
+  /** An isomorphism between a coproduct [[S]] and the sum of its parts.
+    *
+    * {{{
+    *   type ISB = Int :+: String :+: Boolean :+: CNil
+    *
+    *   val iso: Iso[ISB, Int \/ (String \/ Boolean)] = coProductDisjunctionIso[ISB].apply
+    * }}}
+    */
+  def coProductDisjunctionIso[S <: Coproduct]: GenCoProductDisjunctionIso[S] = new GenCoProductDisjunctionIso
+
+  class GenCoProductDisjunctionIso[S <: Coproduct] {
+    def apply[L, R](implicit
+                    coproductToDisjunction: CoproductToDisjunction.Aux[S, L \/ R],
+                    disjunctionToCoproduct: DisjunctionToCoproduct.Aux[L, R, S]
+                   ): Iso[S, L \/ R] =
+      Iso(coproductToDisjunction.apply)(disjunctionToCoproduct.apply)
+  }
+
+  /** An isomorphism between a sum type [[S]] (e.g. a sealed trait) and the sum of its parts.
+    *
+    * {{{
+    *   sealed trait S
+    *   case class A(name: String) extends S
+    *   case class B(name: String) extends S
+    *   case class C(otherName: String) extends S
+    *
+    *   val iso: Iso[S, A \/ (B \/ C)] = coProductToDisjunction[S].apply
+    * }}}
+    */
+  def coProductToDisjunction[S]: GenCoProductToDisjunction[S] = new GenCoProductToDisjunction
+
+  class GenCoProductToDisjunction[S] {
+    def apply[C <: Coproduct, L, R](implicit
+                                    ev: Generic.Aux[S, C],
+                                    coproductToDisjunction: CoproductToDisjunction.Aux[C, L \/ R],
+                                    disjunctionToCoproduct: DisjunctionToCoproduct.Aux[L, R, C]
+                                   ): Iso[S, L \/ R] =
+      generic.toGeneric[S] composeIso coProductDisjunctionIso.apply
+  }
 }
+

--- a/generic/shared/src/main/scala/monocle/generic/GenericOptics.scala
+++ b/generic/shared/src/main/scala/monocle/generic/GenericOptics.scala
@@ -1,0 +1,13 @@
+package monocle.generic
+
+import monocle.Iso
+import shapeless.Generic
+
+object generic extends GenericOptics
+
+trait GenericOptics {
+
+  /** An isomorphism between a type [[S]] and its generic representation. */
+  def toGeneric[S](implicit S: Generic[S]): Iso[S, S.Repr] =
+    Iso[S, S.Repr](S.to(_))(S.from(_))
+}

--- a/generic/shared/src/main/scala/monocle/generic/internal/CoproductToDisjunction.scala
+++ b/generic/shared/src/main/scala/monocle/generic/internal/CoproductToDisjunction.scala
@@ -1,0 +1,35 @@
+package monocle.generic.internal
+
+import scala.{Either => \/}
+import shapeless._
+
+/**
+  * Typeclass converting a [[Coproduct]] to an [[\/]].
+  *
+  * Based on [[shapeless.ops.coproduct.CoproductToEither]]:
+  * https://github.com/milessabin/shapeless/blob/shapeless-2.3.3-scala-2.13.0-M4/core/src/main/scala/shapeless/ops/coproduct.scala#L1275-L1303
+  */
+sealed trait CoproductToDisjunction[C <: Coproduct] extends DepFn1[C] with Serializable
+
+object CoproductToDisjunction {
+  type Aux[In <: Coproduct, Out0] = CoproductToDisjunction[In] { type Out = Out0 }
+
+  implicit def baseToEither[L, R]: CoproductToDisjunction.Aux[L :+: R :+: CNil, L \/ R] = new CoproductToDisjunction[L :+: R :+: CNil] {
+    type Out = L \/ R
+    def apply(t: L :+: R :+: CNil): L \/ R = t match {
+      case Inl(l)         => Left(l)
+      case Inr(Inl(r))    => Right(r)
+      case Inr(Inr(cnil)) => cnil.impossible
+    }
+  }
+
+  implicit def cconsToEither[L, R <: Coproduct, Out0](implicit
+                                                      evR: CoproductToDisjunction.Aux[R, Out0]
+                                                     ): CoproductToDisjunction.Aux[L :+: R, L \/ Out0] = new CoproductToDisjunction[L :+: R] {
+    type Out = L \/ Out0
+    def apply(t: L :+: R): L \/ Out0 = t match {
+      case Inl(l) => Left(l)
+      case Inr(r) => Right(evR(r))
+    }
+  }
+}

--- a/generic/shared/src/main/scala/monocle/generic/internal/DisjunctionToCoproduct.scala
+++ b/generic/shared/src/main/scala/monocle/generic/internal/DisjunctionToCoproduct.scala
@@ -1,0 +1,37 @@
+package monocle.generic.internal
+
+import scala.{Either => \/}
+import shapeless._
+
+/**
+  * Typeclass converting an [[Either]] to a [[\/]].
+  *
+  * Based on [[shapeless.ops.coproduct.EitherToCoproduct]]:
+  * https://github.com/milessabin/shapeless/blob/shapeless-2.3.3-scala-2.13.0-M4/core/src/main/scala/shapeless/ops/coproduct.scala#L1305-L1335
+  */
+sealed trait DisjunctionToCoproduct[L, R] extends DepFn1[L \/ R] with Serializable { type Out <: Coproduct }
+
+object DisjunctionToCoproduct extends DisjunctionToCoproductLowPrio {
+  type Aux[L, R, Out0 <: Coproduct] = DisjunctionToCoproduct[L, R] { type Out = Out0 }
+
+  implicit def econsDisjunctionToCoproduct[L, RL, RR, Out0 <: Coproduct](implicit
+                                                                         evR: DisjunctionToCoproduct.Aux[RL, RR, Out0]
+                                                                        ): DisjunctionToCoproduct.Aux[L, RL \/ RR, L :+: Out0] = new DisjunctionToCoproduct[L, RL \/ RR] {
+    type Out = L :+: Out0
+    def apply(t: L \/ (RL \/ RR)): L :+: Out0 = t match {
+      case Left(l) => Inl(l)
+      case Right(r) => Inr(evR(r))
+    }
+  }
+}
+
+trait DisjunctionToCoproductLowPrio {
+  implicit def baseDisjunctionToCoproduct[L, R]: DisjunctionToCoproduct.Aux[L, R, L :+: R :+: CNil] = new DisjunctionToCoproduct[L, R] {
+    type Out = L :+: R :+: CNil
+
+    def apply(t: L \/ R): L :+: R :+: CNil = t match {
+      case Left(l) => Inl(l)
+      case Right(r) => Coproduct[L :+: R :+: CNil](r)
+    }
+  }
+}

--- a/test/shared/src/test/scala/monocle/generic/CoproductSpec.scala
+++ b/test/shared/src/test/scala/monocle/generic/CoproductSpec.scala
@@ -1,9 +1,9 @@
 package monocle.generic
 
 import monocle.MonocleSuite
-import monocle.law.discipline.PrismTests
+import monocle.law.discipline.{PrismTests, IsoTests}
 import org.scalacheck.Arbitrary._
-import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.{Arbitrary, Cogen, Gen}
 import shapeless.{:+:, CNil, Coproduct, Inl, Inr}
 
 import cats.{Eq => Equal}
@@ -27,4 +27,26 @@ class CoproductSpec extends MonocleSuite {
 
   checkAll("Coproduct Prism", PrismTests(coProductPrism[IB, Boolean]))
 
+  checkAll("Coproduct Either Iso", IsoTests(coProductEitherIso[IB].apply))
+
+  checkAll("Coproduct Disjunction Iso", IsoTests(coProductDisjunctionIso[IB].apply))
+
+  sealed trait S
+  case class A() extends S
+  case object B extends S
+
+  implicit val sArbitrary = Arbitrary[S](Gen.oneOf(A(), B))
+  implicit val sEqual = Equal.instance[S](_ == _)
+
+  implicit val aArb: Arbitrary[A] = Arbitrary(A())
+  implicit val aEq: Equal[A]      = Equal.instance(_ == _)
+  implicit val aCogen: Cogen[A]   = Cogen(_ => 1)
+
+  implicit val bArb: Arbitrary[B.type] = Arbitrary(B)
+  implicit val bEq: Equal[B.type]      = Equal.instance(_ == _)
+  implicit val bCogen: Cogen[B.type]   = Cogen(_ => 2)
+
+  checkAll("Coproduct To Either", IsoTests(coProductToEither[S].apply))
+
+  checkAll("Coproduct To Disjunction", IsoTests(coProductToDisjunction[S].apply))
 }


### PR DESCRIPTION
This is a copy-paste pull request from #609 for cats version

I have an error during local publishing 
```
Monocle/generic/shared/src/main/scala/monocle/generic/GenericOptics.scala:10:3: Could not find any member to link for "S".
[error]   /** An isomorphism between a type [[S]] and its generic representation. */
```
Unfortunately, I didnt have enough time to resolve it, I see the same in master branch without my changes. Is there any proper way to solve it?