### PR TITLE
Fix implicit syntax collisions

### DIFF
--- a/core/shared/src/main/scala/monocle/Prism.scala
+++ b/core/shared/src/main/scala/monocle/Prism.scala
@@ -317,7 +317,7 @@ sealed abstract class PrismInstances {
   }
 }
 
-final case class PrismSyntax[S, A](self: Prism[S, A]) extends AnyVal {
+final case class PrismSyntax[S, A](private val self: Prism[S, A]) extends AnyVal {
 
   /** lift a [[Prism]] such as it only matches if all elements of `F[S]` are getOrModify */
   def below[F[_]](implicit F: Traverse[F]): Prism[F[S], F[A]] =

--- a/core/shared/src/main/scala/monocle/internal/IsEq.scala
+++ b/core/shared/src/main/scala/monocle/internal/IsEq.scala
@@ -9,7 +9,7 @@ final case class IsEq[A](lhs: A, rhs: A)
 object IsEq {
   implicit def syntax[A](lhs: A): IsEqOps[A] = new IsEqOps(lhs)
 
-  final class IsEqOps[A](val lhs: A) extends AnyVal {
+  final class IsEqOps[A](private val lhs: A) extends AnyVal {
     def <==>(rhs: A): IsEq[A] = IsEq(lhs, rhs)
   }
 }

--- a/core/shared/src/main/scala/monocle/syntax/Apply.scala
+++ b/core/shared/src/main/scala/monocle/syntax/Apply.scala
@@ -17,43 +17,43 @@ trait ApplySyntax {
   implicit def toApplyTraversalOps[S](value: S): ApplyTraversalOps[S] = new ApplyTraversalOps(value)
 }
 
-final case class ApplyFoldOps[S](s: S) {
+final case class ApplyFoldOps[S](private val s: S) extends AnyVal {
   def applyFold[A](fold: Fold[S, A]): ApplyFold[S, A] = new ApplyFold[S, A](s, fold)
 }
 
-final case class ApplyGetterOps[S](s: S) {
+final case class ApplyGetterOps[S](private val s: S) extends AnyVal{
   def applyGetter[A](getter: Getter[S, A]): ApplyGetter[S, A] = new ApplyGetter[S, A](s, getter)
 }
 
-final case class ApplyIsoOps[S](s: S) {
+final case class ApplyIsoOps[S](private val s: S) extends AnyVal {
   @inline def applyIso[T, A, B](iso: PIso[S, T, A, B]): ApplyIso[S, T, A, B] = ApplyIso[S, T, A, B](s, iso)
   /** alias to applyIso */
   @inline def &<->[T, A, B](iso: PIso[S, T, A, B]): ApplyIso[S, T, A, B] = applyIso(iso)
 }
 
-final case class ApplyLensOps[S](s: S) {
+final case class ApplyLensOps[S](private val s: S) extends AnyVal {
   def applyLens[T, A, B](lens: PLens[S, T, A, B]): ApplyLens[S, T, A, B] = ApplyLens[S, T, A, B](s, lens)
   /** alias to applyLens */
   def &|->[T, A, B](lens: PLens[S, T, A, B]): ApplyLens[S, T, A, B] = applyLens(lens)
 }
 
-final case class ApplyOptionalOps[S](s: S) {
+final case class ApplyOptionalOps[S](private val s: S) extends AnyVal {
   def applyOptional[T, A, B](optional: POptional[S, T, A, B]): ApplyOptional[S, T, A, B] = ApplyOptional[S, T, A, B](s, optional)
   /** alias to applyOptional */
   def &|-?[T, A, B](optional: POptional[S, T, A, B]): ApplyOptional[S, T, A, B] = applyOptional(optional)
 }
 
-final case class ApplyPrismOps[S](s: S) {
+final case class ApplyPrismOps[S](private val s: S) extends AnyVal {
   def applyPrism[T, A, B](prism: PPrism[S, T, A, B]): ApplyPrism[S, T, A, B] = ApplyPrism[S, T, A, B](s, prism)
   /** alias to applyPrism */
   def &<-?[T, A, B](prism: PPrism[S, T, A, B]): ApplyPrism[S, T, A, B] = applyPrism(prism)
 }
 
-final case class ApplySetterOps[S](s: S) {
+final case class ApplySetterOps[S](private val s: S) extends AnyVal {
   def applySetter[T, A, B](setter: PSetter[S, T, A, B]): ApplySetter[S, T, A, B] = new ApplySetter[S, T, A, B](s, setter)
 }
 
-final case class ApplyTraversalOps[S](s: S) {
+final case class ApplyTraversalOps[S](private val s: S) extends AnyVal {
   def applyTraversal[T, A, B](traversal: PTraversal[S, T, A, B]): ApplyTraversal[S, T, A, B] = ApplyTraversal[S, T, A, B](s, traversal)
   /** alias to applyTraversal */
   def &|->>[T, A, B](traversal: PTraversal[S, T, A, B]): ApplyTraversal[S, T, A, B] = applyTraversal(traversal)

--- a/example/src/test/scala/monocle/LensExample.scala
+++ b/example/src/test/scala/monocle/LensExample.scala
@@ -69,6 +69,16 @@ class LensMonoExample extends MonocleSuite {
   test("@Lenses is for case classes only") {
     illTyped( """@Lenses class C""", "Invalid annotation target: must be a case class")
   }
+
+  test("GenApplyLensOps has no collision with .value") {
+    case class MyString(s: String)
+    object MyString {
+      implicit class Ops(self: MyString) {
+        val value: String = self.s
+      }
+    }
+    MyString("a").value shouldEqual "a"
+  }
 }
 
 class LensPolyExample extends MonocleSuite {

--- a/macro/shared/src/main/scala/monocle/macros/syntax/GenApplyLensSyntax.scala
+++ b/macro/shared/src/main/scala/monocle/macros/syntax/GenApplyLensSyntax.scala
@@ -6,16 +6,23 @@ trait GenApplyLensSyntax {
   implicit def toGenApplyLensOps[S](value: S): GenApplyLensOps[S] = new GenApplyLensOps(value)
 }
 
-class GenApplyLensOps[A](val value: A) extends AnyVal {
+class GenApplyLensOps[A](private val value: A) extends AnyVal {
   def lens[C]( field: A => C ): ApplyLens[A,A,C,C] = macro GenApplyLensOpsImpl.lens_impl[A, C]
 }
 
 class GenApplyLensOpsImpl(val c: blackbox.Context){
   def lens_impl[A: c.WeakTypeTag, C](field: c.Expr[A => C]): c.Expr[ApplyLens[A,A,C,C]] = {
     import c.universe._
+
+    val subj = c.prefix.tree match {
+      case Apply(TypeApply(_, _), List(x)) => x
+      case t =>
+        c.abort(c.enclosingPosition, s"Invalid prefix tree ${show(t)}")
+    }
+
     c.Expr[ApplyLens[A,A,C,C]](q"""
       _root_.monocle.syntax.ApplyLens(
-        ${c.prefix.tree}.value,
+        $subj,
         _root_.monocle.macros.GenLens[${c.weakTypeOf[A]}](${field})
       )
     """)

--- a/state/shared/src/main/scala/monocle/state/ReaderGetterSyntax.scala
+++ b/state/shared/src/main/scala/monocle/state/ReaderGetterSyntax.scala
@@ -9,7 +9,7 @@ trait ReaderGetterSyntax {
     new ReaderGetterOps[S, A](getter)
 }
 
-final class ReaderGetterOps[S, A](getter: Getter[S, A]) {
+final class ReaderGetterOps[S, A](private val getter: Getter[S, A]) extends AnyVal {
   /** transforms a Getter into a Reader */
   def toReader: Reader[S, A] =
     Reader(getter.get)

--- a/state/shared/src/main/scala/monocle/state/StateGetterSyntax.scala
+++ b/state/shared/src/main/scala/monocle/state/StateGetterSyntax.scala
@@ -9,7 +9,7 @@ trait StateGetterSyntax {
     new StateGetterOps[S, A](getter)
 }
 
-final class StateGetterOps[S, A](getter: Getter[S, A]) {
+final class StateGetterOps[S, A](private val getter: Getter[S, A]) extends AnyVal {
   /** transforms a Getter into a State */
   def toState: State[S, A] =
     State(s => (s, getter.get(s)))

--- a/state/shared/src/main/scala/monocle/state/StateLensSyntax.scala
+++ b/state/shared/src/main/scala/monocle/state/StateLensSyntax.scala
@@ -9,7 +9,7 @@ trait StateLensSyntax {
     new StateLensOps[S, T, A, B](lens)
 }
 
-final class StateLensOps[S, T, A, B](lens: PLens[S, T, A, B]) {
+final class StateLensOps[S, T, A, B](private val lens: PLens[S, T, A, B]) extends AnyVal {
   /** transforms a PLens into a State */
   def toState: State[S, A] =
     State(s => (s, lens.get(s)))

--- a/state/shared/src/main/scala/monocle/state/StateOptionalSyntax.scala
+++ b/state/shared/src/main/scala/monocle/state/StateOptionalSyntax.scala
@@ -9,7 +9,7 @@ trait StateOptionalSyntax {
     new StateOptionalOps[S, T, A, B](optional)
 }
 
-final class StateOptionalOps[S, T, A, B](optional: POptional[S, T, A, B]) {
+final class StateOptionalOps[S, T, A, B](private val optional: POptional[S, T, A, B]) extends AnyVal {
   /** transforms a POptional into a State */
   def toState: State[S, Option[A]] =
     State(s => (s, optional.getOption(s)))

--- a/state/shared/src/main/scala/monocle/state/StateSetterSyntax.scala
+++ b/state/shared/src/main/scala/monocle/state/StateSetterSyntax.scala
@@ -9,7 +9,7 @@ trait StateSetterSyntax {
     new StateSetterOps[S, T, A, B](setter)
 }
 
-final class StateSetterOps[S, T, A, B](setter: PSetter[S, T, A, B]) {
+final class StateSetterOps[S, T, A, B](private val setter: PSetter[S, T, A, B]) extends AnyVal {
   /** modify the value referenced through the setter */
   def mod_(f: A => B): IndexedState[S, T, Unit] =
     IndexedState(s => (setter.modify(f)(s), ()))

--- a/state/shared/src/main/scala/monocle/state/StateTraversalSyntax.scala
+++ b/state/shared/src/main/scala/monocle/state/StateTraversalSyntax.scala
@@ -9,7 +9,7 @@ trait StateTraversalSyntax {
     new StateTraversalOps[S, T, A, B](traversal)
 }
 
-final class StateTraversalOps[S, T, A, B](traversal: PTraversal[S, T, A, B]) {
+final class StateTraversalOps[S, T, A, B](private val traversal: PTraversal[S, T, A, B]) extends AnyVal {
   /** transforms a PTraversal into a State */
   def toState: State[S, List[A]] =
     State(s => (s, traversal.getAll(s)))


### PR DESCRIPTION
This PR fixes a collision when we use something like [scala-newtype](https://github.com/estatico/scala-newtype) and have `import monocle.macros.syntax.lens._` in scope.  A cause of collision is `val value: A` in `GenApplyLensOps` so it conflicts with any `.value` that is defined via implicit syntax. The same issue was fixed in Cats code base - see https://github.com/typelevel/cats/issues/2491 and 
https://github.com/typelevel/cats/pull/2614.
Proposed change can be considered as binary compatible - unless someone used `GenApplyLensOps.value` in code which is unlikely. We can probably do a bit more and replace  `toGenApplyLensOps` and `GenApplyLensOps` with single implicit class - as Scala looks to be not instantiating it for macro based syntax. But this change can break some code using GenApplyLensOps directly, so for now I'm just making `.value` private and replace access to it in macro with pattern matching on tree. 