### PR TITLE
kind-projector org change (and sbt version bump)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -58,7 +58,7 @@ lazy val macroCompat       = Def.setting("org.typelevel"              %%% "macro
 
 lazy val macroVersion = "2.1.1"
 lazy val paradisePlugin = "org.scalamacros" % "paradise"       % macroVersion cross CrossVersion.patch
-lazy val kindProjector  = "org.spire-math"  % "kind-projector" % "0.9.5" cross CrossVersion.binary
+lazy val kindProjector  = "org.typelevel" % "kind-projector" % "0.10.0" cross CrossVersion.binary
 
 def mimaSettings(module: String): Seq[Setting[_]] = mimaDefaultSettings ++ Seq(
   mimaPreviousArtifacts := Set("com.github.julien-truffaut" %  (s"monocle-${module}_2.11") % "1.3.0")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.4
+sbt.version=1.2.8


### PR DESCRIPTION
it would helpful in the Scala community build to have this merged,
normally we can override org changes like this in our config, but I'm
having trouble I don't understand. and anyway, using the latest
versions is generally a good thing

the sbt bump isn't a necessary part of this, but it may help avert
unexpected community build trouble as well