### PR TITLE
Add Scala Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,19 @@
+# Code of Conduct
+
+We are committed to providing a friendly, safe and welcoming
+environment for all, regardless of level of experience, gender, gender
+identity and expression, sexual orientation, disability, personal
+appearance, body size, race, ethnicity, age, religion, nationality, or
+other such characteristics.
+
+Everyone is expected to follow the [Scala Code of Conduct] when
+discussing the project on the available communication channels. If you
+are being harassed, please contact us immediately so that we can
+support you.
+
+## Moderation
+
+For any questions, concerns, or moderation requests please contact a
+member of the project.
+
+[Scala Code of Conduct]: https://typelevel.org/code-of-conduct.html


### PR DESCRIPTION
Typelevel is [switching to the Scala Code of Conduct](https://typelevel.org/blog/2019/05/01/typelevel-switches-to-scala-code-of-conduct.html), and encourages all member projects to adopt it.