### PR TITLE
Remove sbt-release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -115,20 +115,16 @@ def mimaSettings(module: String): Seq[Setting[_]] = mimaDefaultSettings ++ Seq(
   mimaPreviousArtifacts := Set("com.github.julien-truffaut" %%  (s"monocle-${module}") % "1.6.0")
 )
 
-lazy val tagName = Def.setting(
- s"v${if (releaseUseGlobalVersion.value) (version in ThisBuild).value else version.value}")
-
 lazy val gitRev = sys.process.Process("git rev-parse HEAD").lineStream_!.head
 
 lazy val scalajsSettings = Seq(
   scalacOptions += {
-    lazy val tag = tagName.value
+    lazy val tag = (version in ThisBuild).value
     val s = if (isSnapshot.value) gitRev else tag
     val a = (baseDirectory in LocalRootProject).value.toURI.toString
     val g = "https://raw.githubusercontent.com/julien-truffaut/Monocle"
     s"-P:scalajs:mapSourceURI:$a->$g/$s/"
   },
-  jsEnv := new org.scalajs.jsenv.nodejs.NodeJSEnv(),
   testOptions in Test += Tests.Argument(TestFrameworks.ScalaCheck, "-maxSize", "8", "-minSuccessfulTests", "50")
 )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,4 @@
 addSbtPlugin("com.eed3si9n"       % "sbt-unidoc"                    % "0.4.2")
-addSbtPlugin("com.github.gseitz"  % "sbt-release"                   % "1.0.11")
 addSbtPlugin("com.geirsson"       % "sbt-ci-release"                % "1.4.31")
 addSbtPlugin("com.typesafe"       % "sbt-mima-plugin"               % "0.6.0")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh"                       % "0.3.7")


### PR DESCRIPTION
I think sbt-release isn't needed and could be removed. This assumes we have a single common version which I think is true for monocle.
Note the `jsEnv` setting set in the build is now the default in scala.js and can be removed