### PR TITLE
At - Index typeclass

### DIFF
--- a/kernel/shared/src/main/scala/monocle/Lens.scala
+++ b/kernel/shared/src/main/scala/monocle/Lens.scala
@@ -1,6 +1,6 @@
 package monocle
 
-import monocle.function.{Field1, Field2}
+import monocle.function.{At, Field1, Field2}
 
 trait Lens[A, B] extends Optional[A, B] { self =>
   def get(from: A): B
@@ -22,6 +22,12 @@ object Lens {
     def set(to: B): A => A = _set(_, to)
   }
 
-  def first[S, A](implicit ev: Field1.Aux[S, A]): Lens[S, A] = ev.first
-  def second[S, A](implicit ev: Field2.Aux[S, A]): Lens[S, A] = ev.second
+  def at[S, I, A](index: I)(implicit ev: At.Aux[S, I, A]): Lens[S, Option[A]] =
+    ev.at(index)
+
+  def first[S, A](implicit ev: Field1.Aux[S, A]): Lens[S, A] =
+    ev.first
+
+  def second[S, A](implicit ev: Field2.Aux[S, A]): Lens[S, A] =
+    ev.second
 }

--- a/kernel/shared/src/main/scala/monocle/Optional.scala
+++ b/kernel/shared/src/main/scala/monocle/Optional.scala
@@ -1,6 +1,6 @@
 package monocle
 
-import monocle.function.Cons
+import monocle.function.{Cons, Index}
 
 trait Optional[A, B] { self =>
   def getOption(from: A): Option[B]
@@ -15,6 +15,7 @@ trait Optional[A, B] { self =>
   }
 
   def composeLens[C](other: Lens[B, C]): Optional[A, C] = compose(other)
+  def composePrism[C](other: Prism[B, C]): Optional[A, C] = compose(other)
 }
 
 object Optional {
@@ -23,8 +24,14 @@ object Optional {
     def set(to: B): A => A = _set(_, to)
   }
 
+  def void[S, A]: Optional[S, A] =
+    Optional[S, A](_ => None)((a, _) => a)
+
   def headOption[S, A](implicit ev: Cons.Aux[S, A]): Optional[S, A] =
     ev.headOption
+
+  def index[S, I, A](index: I)(implicit ev: Index.Aux[S, I, A]): Optional[S, A] =
+    ev.index(index)
 
   def tailOption[S](implicit ev: Cons[S]): Optional[S, S] =
     ev.tailOption

--- a/kernel/shared/src/main/scala/monocle/function/At.scala
+++ b/kernel/shared/src/main/scala/monocle/function/At.scala
@@ -25,7 +25,7 @@ object At {
     apply((key: K) =>
       Lens[Map[K, V], Option[V]](_.get(key))((map, optA) =>
         optA match {
-          case None    => map.removed(key)
+          case None    => map - key
           case Some(a) => map + (key -> a)
         }
       )

--- a/kernel/shared/src/main/scala/monocle/function/At.scala
+++ b/kernel/shared/src/main/scala/monocle/function/At.scala
@@ -1,0 +1,33 @@
+package monocle.function
+
+import monocle.{Lens, Optional}
+import monocle.Prism.some
+
+trait At[S] extends Index[S] {
+
+  def at(index: I): Lens[S, Option[A]]
+
+  def index(index: I): Optional[S, A] =
+    at(index) composePrism some
+}
+
+object At {
+  type Aux[S, I0, A0] = At[S] { type I = I0; type A = A0 }
+
+  def apply[S, I0, A0](f : I0 => Lens[S, Option[A0]]): Aux[S, I0, A0] =
+    new At[S] {
+      type I = I0
+      type A = A0
+      def at(index: I0): Lens[S, Option[A0]] = f(index)
+    }
+
+  def map[K, V]: Aux[Map[K, V], K, V] =
+    apply((key: K) =>
+      Lens[Map[K, V], Option[V]](_.get(key))((map, optA) =>
+        optA match {
+          case None    => map.removed(key)
+          case Some(a) => map + (key -> a)
+        }
+      )
+    )
+}

--- a/kernel/shared/src/main/scala/monocle/function/At.scala
+++ b/kernel/shared/src/main/scala/monocle/function/At.scala
@@ -21,7 +21,7 @@ object At {
       def at(index: I0): Lens[S, Option[A0]] = f(index)
     }
 
-  def map[K, V]: Aux[Map[K, V], K, V] =
+  implicit def map[K, V]: Aux[Map[K, V], K, V] =
     apply((key: K) =>
       Lens[Map[K, V], Option[V]](_.get(key))((map, optA) =>
         optA match {

--- a/kernel/shared/src/main/scala/monocle/function/Cons.scala
+++ b/kernel/shared/src/main/scala/monocle/function/Cons.scala
@@ -14,4 +14,16 @@ trait Cons[S] {
 
 object Cons {
   type Aux[S, A0] = Cons[S] { type A = A0 }
+
+  def apply[S, A0](prism: Prism[S, (A0, S)]): Aux[S, A0] =
+    new Cons[S] {
+      type A = A0
+      def cons: Prism[S, (A0, S)] = prism
+    }
+
+  implicit def list[A]: Cons[List[A]] =
+    apply(Prism[List[A], (A, List[A])]{
+      case Nil     => None
+      case x :: xs => Some((x, xs))
+    }{ case (x, xs) => x :: xs })
 }

--- a/kernel/shared/src/main/scala/monocle/function/Index.scala
+++ b/kernel/shared/src/main/scala/monocle/function/Index.scala
@@ -21,7 +21,7 @@ object Index {
       def index(index: I0): Optional[S, A0] = f(index)
     }
 
-  def list[A]: Aux[List[A], Int, A] =
+  implicit def list[A]: Aux[List[A], Int, A] =
     apply((i: Int) =>
       if (i < 0)
         Optional.void

--- a/kernel/shared/src/main/scala/monocle/function/Index.scala
+++ b/kernel/shared/src/main/scala/monocle/function/Index.scala
@@ -1,0 +1,31 @@
+package monocle.function
+
+import monocle.Optional
+
+import scala.util.Try
+
+trait Index[S] {
+  type I
+  type A
+
+  def index(index: I): Optional[S, A]
+}
+
+object Index {
+  type Aux[S, I0, A0] = Index[S] { type I = I0; type A = A0 }
+
+  def apply[S, I0, A0](f : I0 => Optional[S, A0]): Aux[S, I0, A0] =
+    new Index[S] {
+      type I = I0
+      type A = A0
+      def index(index: I0): Optional[S, A0] = f(index)
+    }
+
+  def list[A]: Aux[List[A], Int, A] =
+    apply((i: Int) =>
+      if (i < 0)
+        Optional.void
+      else
+        Optional[List[A], A](xs => Try(xs(i)).toOption)((xs, a) => Try(xs.updated(i, a)).getOrElse(xs))
+    )
+}

--- a/kernel/shared/src/main/scala/monocle/function/Index.scala
+++ b/kernel/shared/src/main/scala/monocle/function/Index.scala
@@ -28,4 +28,6 @@ object Index {
       else
         Optional[List[A], A](xs => Try(xs(i)).toOption)((xs, a) => Try(xs.updated(i, a)).getOrElse(xs))
     )
+
+  implicit def map[K, V]: Aux[Map[K, V], K, V] = At.map
 }


### PR DESCRIPTION
- I used the same encoding as for `FieldX` and `Cons`.
- Introduced inheritance between `At` and `Index`
- I wonder if we should have an `AtK` version for higher kinded `S`, e.g. `Atk[List, Int]` instead of `At[List[A], Int, A]` 

