### PR TITLE
Harmonise type parameters

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -86,12 +86,12 @@ lazy val cats              = Def.setting("org.typelevel"     %%% "cats-core"    
 lazy val catsFree          = Def.setting("org.typelevel"     %%% "cats-free"                % catsVersion)
 lazy val catsLaws          = Def.setting("org.typelevel"     %%% "cats-laws"                % catsVersion)
 lazy val alleycats         = Def.setting("org.typelevel"     %%% "alleycats-core"           % catsVersion)
-lazy val scalaz            = Def.setting("org.scalaz"        %%% "scalaz-core"              % "7.2.28")
+lazy val scalaz            = Def.setting("org.scalaz"        %%% "scalaz-core"              % "7.2.29")
 lazy val shapeless         = Def.setting("com.chuusai"       %%% "shapeless"                % "2.3.3")
 lazy val refinedDep        = Def.setting("eu.timepit"        %%% "refined"                  % "0.9.10")
 lazy val refinedScalacheck = Def.setting("eu.timepit"        %%% "refined-scalacheck"       % "0.9.10" % "test")
 
-lazy val discipline        = Def.setting("org.typelevel"     %%% "discipline-scalatest"     % "1.0.0-M1")
+lazy val discipline        = Def.setting("org.typelevel"     %%% "discipline-scalatest"     % "1.0.0-RC1")
 lazy val scalacheck        = Def.setting("org.scalacheck"    %%% "scalacheck"               % "1.14.2")
 lazy val scalatestplus     = Def.setting("org.scalatestplus" %%% "scalatestplus-scalacheck" % "1.0.0-SNAP8" % "test")
 lazy val scalatest         = Def.setting("org.scalatest"     %%% "scalatest"                % scalatestVersion.value % "test")
@@ -109,26 +109,22 @@ lazy val paradisePlugin = Def.setting{
   }
 }
 
-lazy val kindProjector  = "org.typelevel"  % "kind-projector" % "0.10.3" cross CrossVersion.binary
+lazy val kindProjector  = "org.typelevel" % "kind-projector" % "0.11.0" cross CrossVersion.full
 
 def mimaSettings(module: String): Seq[Setting[_]] = mimaDefaultSettings ++ Seq(
   mimaPreviousArtifacts := Set("com.github.julien-truffaut" %%  (s"monocle-${module}") % "1.6.0")
 )
 
-lazy val tagName = Def.setting(
- s"v${if (releaseUseGlobalVersion.value) (version in ThisBuild).value else version.value}")
-
 lazy val gitRev = sys.process.Process("git rev-parse HEAD").lineStream_!.head
 
 lazy val scalajsSettings = Seq(
   scalacOptions += {
-    lazy val tag = tagName.value
+    lazy val tag = (version in ThisBuild).value
     val s = if (isSnapshot.value) gitRev else tag
     val a = (baseDirectory in LocalRootProject).value.toURI.toString
     val g = "https://raw.githubusercontent.com/julien-truffaut/Monocle"
     s"-P:scalajs:mapSourceURI:$a->$g/$s/"
   },
-  jsEnv := new org.scalajs.jsenv.nodejs.NodeJSEnv(),
   testOptions in Test += Tests.Argument(TestFrameworks.ScalaCheck, "-maxSize", "8", "-minSuccessfulTests", "50")
 )
 

--- a/dotSyntax/src/main/scala/monocle/syntax/AppliedIso.scala
+++ b/dotSyntax/src/main/scala/monocle/syntax/AppliedIso.scala
@@ -10,25 +10,28 @@ trait AppliedIso[A, B] extends AppliedLens[A, B] with AppliedPrism[A, B] {
   final def compose[C](other: Iso[B, C]): AppliedIso[A, C] =
     AppliedIso(value, optic.compose(other))
 
-  override final def _1(implicit ev: Field1[B]): AppliedLens[A, ev.A] = first
-  override final def _2(implicit ev: Field2[B]): AppliedLens[A, ev.A] = second
+  override final def _1(implicit ev: Field1[B]): AppliedLens[A, ev.B] = first
+  override final def _2(implicit ev: Field2[B]): AppliedLens[A, ev.B] = second
 
-  override final def at[I, C](i: I)(implicit ev: At.Aux[B, I, C]): AppliedLens[A, Option[C]] =
+  override final def at[I, C](i: I)(
+      implicit ev: At.Aux[B, I, C]): AppliedLens[A, Option[C]] =
     compose(ev.at(i))
 
-  override final def cons(implicit ev: Cons[B]): AppliedPrism[A, (ev.A, B)] =
+  override final def cons(implicit ev: Cons[B]): AppliedPrism[A, (ev.B, B)] =
     compose(ev.cons)
 
-  override final def first(implicit ev: Field1[B]): AppliedLens[A, ev.A] =
+  override final def first(implicit ev: Field1[B]): AppliedLens[A, ev.B] =
     compose(ev.first)
 
-  override final def left[E, C](implicit ev: B =:= Either[E, C]): AppliedPrism[A, E] =
+  override final def left[E, C](
+      implicit ev: B =:= Either[E, C]): AppliedPrism[A, E] =
     asTarget[Either[E, C]].compose(Prism.left[E, C])
 
-  override final def right[E, C](implicit ev: B =:= Either[E, C]): AppliedPrism[A, C] =
+  override final def right[E, C](
+      implicit ev: B =:= Either[E, C]): AppliedPrism[A, C] =
     asTarget[Either[E, C]].compose(Prism.right[E, C])
 
-  override final def second(implicit ev: Field2[B]): AppliedLens[A, ev.A] =
+  override final def second(implicit ev: Field2[B]): AppliedLens[A, ev.B] =
     compose(ev.second)
 
   override final def some[C](implicit ev: B =:= Option[C]): AppliedPrism[A, C] =

--- a/dotSyntax/src/main/scala/monocle/syntax/AppliedLens.scala
+++ b/dotSyntax/src/main/scala/monocle/syntax/AppliedLens.scala
@@ -3,7 +3,7 @@ package monocle.syntax
 import monocle.Lens
 import monocle.function.{At, Field1, Field2}
 
-trait AppliedLens[A, B] extends AppliedOptional[A, B]{
+trait AppliedLens[A, B] extends AppliedOptional[A, B] {
   def value: A
   def optic: Lens[A, B]
 
@@ -13,16 +13,17 @@ trait AppliedLens[A, B] extends AppliedOptional[A, B]{
   def compose[C](other: Lens[B, C]): AppliedLens[A, C] =
     AppliedLens(value, optic.compose(other))
 
-  override def _1(implicit ev: Field1[B]): AppliedLens[A, ev.A] = first
-  override def _2(implicit ev: Field2[B]): AppliedLens[A, ev.A] = second
+  override def _1(implicit ev: Field1[B]): AppliedLens[A, ev.B] = first
+  override def _2(implicit ev: Field2[B]): AppliedLens[A, ev.B] = second
 
-  override def at[I, C](i: I)(implicit ev: At.Aux[B, I, C]): AppliedLens[A, Option[C]] =
+  override def at[I, C](i: I)(
+      implicit ev: At.Aux[B, I, C]): AppliedLens[A, Option[C]] =
     compose(ev.at(i))
 
-  override def first(implicit ev: Field1[B]): AppliedLens[A, ev.A] =
+  override def first(implicit ev: Field1[B]): AppliedLens[A, ev.B] =
     compose(ev.first)
 
-  override def second(implicit ev: Field2[B]): AppliedLens[A, ev.A] =
+  override def second(implicit ev: Field2[B]): AppliedLens[A, ev.B] =
     compose(ev.second)
 
   override def asTarget[C](implicit ev: B =:= C): AppliedLens[A, C] =

--- a/dotSyntax/src/main/scala/monocle/syntax/AppliedOptional.scala
+++ b/dotSyntax/src/main/scala/monocle/syntax/AppliedOptional.scala
@@ -19,22 +19,24 @@ trait AppliedOptional[A, B] {
   def compose[C](other: Optional[B, C]): AppliedOptional[A, C] =
     AppliedOptional(value, optic.compose(other))
 
-  def _1(implicit ev: Field1[B]): AppliedOptional[A, ev.A] = first
-  def _2(implicit ev: Field2[B]): AppliedOptional[A, ev.A] = second
+  def _1(implicit ev: Field1[B]): AppliedOptional[A, ev.B] = first
+  def _2(implicit ev: Field2[B]): AppliedOptional[A, ev.B] = second
 
-  def at[I, C](i: I)(implicit ev: At.Aux[B, I, C]): AppliedOptional[A, Option[C]] =
+  def at[I, C](i: I)(
+      implicit ev: At.Aux[B, I, C]): AppliedOptional[A, Option[C]] =
     compose(ev.at(i))
 
-  def cons(implicit ev: Cons[B]): AppliedOptional[A, (ev.A, B)] =
+  def cons(implicit ev: Cons[B]): AppliedOptional[A, (ev.B, B)] =
     compose(ev.cons)
 
-  def first(implicit ev: Field1[B]): AppliedOptional[A, ev.A] =
+  def first(implicit ev: Field1[B]): AppliedOptional[A, ev.B] =
     compose(ev.first)
 
-  def headOption(implicit ev: Cons[B]): AppliedOptional[A, ev.A] =
-   compose(ev.headOption)
+  def headOption(implicit ev: Cons[B]): AppliedOptional[A, ev.B] =
+    compose(ev.headOption)
 
-  def index[I, C](i: I)(implicit ev: Index.Aux[B, I, C]): AppliedOptional[A, C] =
+  def index[I, C](i: I)(
+      implicit ev: Index.Aux[B, I, C]): AppliedOptional[A, C] =
     compose(ev.index(i))
 
   def left[E, C](implicit ev: B =:= Either[E, C]): AppliedOptional[A, E] =
@@ -43,7 +45,7 @@ trait AppliedOptional[A, B] {
   def right[E, C](implicit ev: B =:= Either[E, C]): AppliedOptional[A, C] =
     asTarget[Either[E, C]].compose(Prism.right[E, C])
 
-  def second(implicit ev: Field2[B]): AppliedOptional[A, ev.A] =
+  def second(implicit ev: Field2[B]): AppliedOptional[A, ev.B] =
     compose(ev.second)
 
   def some[C](implicit ev: B =:= Option[C]): AppliedOptional[A, C] =

--- a/dotSyntax/src/main/scala/monocle/syntax/AppliedPrism.scala
+++ b/dotSyntax/src/main/scala/monocle/syntax/AppliedPrism.scala
@@ -10,13 +10,14 @@ trait AppliedPrism[A, B] extends AppliedOptional[A, B] {
   def compose[C](other: Prism[B, C]): AppliedPrism[A, C] =
     AppliedPrism(value, optic.compose(other))
 
-  override def cons(implicit ev: Cons[B]): AppliedPrism[A, (ev.A, B)] =
+  override def cons(implicit ev: Cons[B]): AppliedPrism[A, (ev.B, B)] =
     compose(ev.cons)
 
   override def left[E, C](implicit ev: B =:= Either[E, C]): AppliedPrism[A, E] =
     asTarget[Either[E, C]].compose(Prism.left[E, C])
 
-  override def right[E, C](implicit ev: B =:= Either[E, C]): AppliedPrism[A, C] =
+  override def right[E, C](
+      implicit ev: B =:= Either[E, C]): AppliedPrism[A, C] =
     asTarget[Either[E, C]].compose(Prism.right[E, C])
 
   override def some[C](implicit ev: B =:= Option[C]): AppliedPrism[A, C] =

--- a/dotSyntax/src/main/scala/monocle/syntax/iso.scala
+++ b/dotSyntax/src/main/scala/monocle/syntax/iso.scala
@@ -7,19 +7,19 @@ object iso extends IsoSyntax
 
 trait IsoSyntax {
   implicit class IsoOps[A, B](optic: Iso[A, B]) {
-    def _1(implicit ev: Field1[B]): Lens[A, ev.A] = first(ev)
-    def _2(implicit ev: Field2[B]): Lens[A, ev.A] = second(ev)
+    def _1(implicit ev: Field1[B]): Lens[A, ev.B] = first(ev)
+    def _2(implicit ev: Field2[B]): Lens[A, ev.B] = second(ev)
 
     def at[I, C](i: I)(implicit ev: At.Aux[B, I, C]): Lens[A, Option[C]] =
       optic.compose(ev.at(i))
 
-    def cons(implicit ev: Cons[B]): Optional[A, (ev.A, B)] =
+    def cons(implicit ev: Cons[B]): Optional[A, (ev.B, B)] =
       optic.compose(ev.cons)
 
-    def first(implicit ev: Field1[B]): Lens[A, ev.A] =
+    def first(implicit ev: Field1[B]): Lens[A, ev.B] =
       optic.compose(ev.first)
 
-    def headOption(implicit ev: Cons[B]): Optional[A, ev.A] =
+    def headOption(implicit ev: Cons[B]): Optional[A, ev.B] =
       optic.compose(ev.headOption)
 
     def index[I, C](i: I)(implicit ev: Index.Aux[B, I, C]): Optional[A, C] =
@@ -31,7 +31,7 @@ trait IsoSyntax {
     def right[E, C](implicit ev: B =:= Either[E, C]): Prism[A, C] =
       optic.asTarget[Either[E, C]].compose(Prism.right[E, C])
 
-    def second(implicit ev: Field2[B]): Lens[A, ev.A] =
+    def second(implicit ev: Field2[B]): Lens[A, ev.B] =
       optic.compose(ev.second)
 
     def some[C](implicit ev: B =:= Option[C]): Prism[A, C] =

--- a/dotSyntax/src/main/scala/monocle/syntax/lens.scala
+++ b/dotSyntax/src/main/scala/monocle/syntax/lens.scala
@@ -7,19 +7,19 @@ object lens extends LensSyntax
 
 trait LensSyntax {
   implicit class LensOps[A, B](optic: Lens[A, B]) {
-    def _1(implicit ev: Field1[B]): Lens[A, ev.A] = first(ev)
-    def _2(implicit ev: Field2[B]): Lens[A, ev.A] = second(ev)
+    def _1(implicit ev: Field1[B]): Lens[A, ev.B] = first(ev)
+    def _2(implicit ev: Field2[B]): Lens[A, ev.B] = second(ev)
 
     def at[I, C](i: I)(implicit ev: At.Aux[B, I, C]): Lens[A, Option[C]] =
       optic.compose(ev.at(i))
 
-    def cons(implicit ev: Cons[B]): Optional[A, (ev.A, B)] =
+    def cons(implicit ev: Cons[B]): Optional[A, (ev.B, B)] =
       optic.compose(ev.cons)
 
-    def first(implicit ev: Field1[B]): Lens[A, ev.A] =
+    def first(implicit ev: Field1[B]): Lens[A, ev.B] =
       optic.compose(ev.first)
 
-    def headOption(implicit ev: Cons[B]): Optional[A, ev.A] =
+    def headOption(implicit ev: Cons[B]): Optional[A, ev.B] =
       optic.compose(ev.headOption)
 
     def index[I, C](i: I)(implicit ev: Index.Aux[B, I, C]): Optional[A, C] =
@@ -31,7 +31,7 @@ trait LensSyntax {
     def right[E, C](implicit ev: B =:= Either[E, C]): Optional[A, C] =
       optic.asTarget[Either[E, C]].compose(Prism.right[E, C])
 
-    def second(implicit ev: Field2[B]): Lens[A, ev.A] =
+    def second(implicit ev: Field2[B]): Lens[A, ev.B] =
       optic.compose(ev.second)
 
     def some[C](implicit ev: B =:= Option[C]): Optional[A, C] =
@@ -41,4 +41,3 @@ trait LensSyntax {
       optic.compose(ev.tailOption)
   }
 }
-

--- a/dotSyntax/src/main/scala/monocle/syntax/optional.scala
+++ b/dotSyntax/src/main/scala/monocle/syntax/optional.scala
@@ -7,19 +7,19 @@ object optional extends LensSyntax
 
 trait OptionalSyntax {
   implicit class OptionalOps[A, B](optic: Optional[A, B]) {
-    def _1(implicit ev: Field1[B]): Optional[A, ev.A] = first(ev)
-    def _2(implicit ev: Field2[B]): Optional[A, ev.A] = second(ev)
+    def _1(implicit ev: Field1[B]): Optional[A, ev.B] = first(ev)
+    def _2(implicit ev: Field2[B]): Optional[A, ev.B] = second(ev)
 
     def at[I, C](i: I)(implicit ev: At.Aux[B, I, C]): Optional[A, Option[C]] =
       optic.compose(ev.at(i))
 
-    def cons(implicit ev: Cons[B]): Optional[A, (ev.A, B)] =
+    def cons(implicit ev: Cons[B]): Optional[A, (ev.B, B)] =
       optic.compose(ev.cons)
 
-    def first(implicit ev: Field1[B]): Optional[A, ev.A] =
+    def first(implicit ev: Field1[B]): Optional[A, ev.B] =
       optic.compose(ev.first)
 
-    def headOption(implicit ev: Cons[B]): Optional[A, ev.A] =
+    def headOption(implicit ev: Cons[B]): Optional[A, ev.B] =
       optic.compose(ev.headOption)
 
     def index[I, C](i: I)(implicit ev: Index.Aux[B, I, C]): Optional[A, C] =
@@ -31,7 +31,7 @@ trait OptionalSyntax {
     def right[E, C](implicit ev: B =:= Either[E, C]): Optional[A, C] =
       optic.asTarget[Either[E, C]].compose(Prism.right[E, C])
 
-    def second(implicit ev: Field2[B]): Optional[A, ev.A] =
+    def second(implicit ev: Field2[B]): Optional[A, ev.B] =
       optic.compose(ev.second)
 
     def some[C](implicit ev: B =:= Option[C]): Optional[A, C] =
@@ -42,4 +42,3 @@ trait OptionalSyntax {
   }
 
 }
-

--- a/dotSyntax/src/main/scala/monocle/syntax/prism.scala
+++ b/dotSyntax/src/main/scala/monocle/syntax/prism.scala
@@ -7,19 +7,19 @@ object prism extends PrismSyntax
 
 trait PrismSyntax {
   implicit class PrismSyntaxOps[A, B](optic: Prism[A, B]) {
-    def _1(implicit ev: Field1[B]): Optional[A, ev.A] = first(ev)
-    def _2(implicit ev: Field2[B]): Optional[A, ev.A] = second(ev)
+    def _1(implicit ev: Field1[B]): Optional[A, ev.B] = first(ev)
+    def _2(implicit ev: Field2[B]): Optional[A, ev.B] = second(ev)
 
     def at[I, C](i: I)(implicit ev: At.Aux[B, I, C]): Optional[A, Option[C]] =
       optic.compose(ev.at(i))
 
-    def cons(implicit ev: Cons[B]): Prism[A, (ev.A, B)] =
+    def cons(implicit ev: Cons[B]): Prism[A, (ev.B, B)] =
       optic.compose(ev.cons)
 
-    def first(implicit ev: Field1[B]): Optional[A, ev.A] =
+    def first(implicit ev: Field1[B]): Optional[A, ev.B] =
       optic.compose(ev.first)
 
-    def headOption(implicit ev: Cons[B]): Optional[A, ev.A] =
+    def headOption(implicit ev: Cons[B]): Optional[A, ev.B] =
       optic.compose(ev.headOption)
 
     def index[I, C](i: I)(implicit ev: Index.Aux[B, I, C]): Optional[A, C] =
@@ -31,7 +31,7 @@ trait PrismSyntax {
     def right[E, C](implicit ev: B =:= Either[E, C]): Prism[A, C] =
       optic.asTarget[Either[E, C]].compose(Prism.right[E, C])
 
-    def second(implicit ev: Field2[B]): Optional[A, ev.A] =
+    def second(implicit ev: Field2[B]): Optional[A, ev.B] =
       optic.compose(ev.second)
 
     def some[C](implicit ev: B =:= Option[C]): Prism[A, C] =
@@ -42,4 +42,3 @@ trait PrismSyntax {
   }
 
 }
-

--- a/kernel/shared/src/main/scala/monocle/function/At.scala
+++ b/kernel/shared/src/main/scala/monocle/function/At.scala
@@ -3,22 +3,22 @@ package monocle.function
 import monocle.{Lens, Optional}
 import monocle.Prism.some
 
-trait At[S] extends Index[S] {
+trait At[A] extends Index[A] {
 
-  def at(index: I): Lens[S, Option[A]]
+  def at(index: I): Lens[A, Option[B]]
 
-  def index(index: I): Optional[S, A] =
+  def index(index: I): Optional[A, B] =
     at(index) composePrism some
 }
 
 object At {
-  type Aux[S, I0, A0] = At[S] { type I = I0; type A = A0 }
+  type Aux[A, I0, B0] = At[A] { type I = I0; type B = B0 }
 
-  def apply[S, I0, A0](f : I0 => Lens[S, Option[A0]]): Aux[S, I0, A0] =
-    new At[S] {
+  def apply[A, I0, B0](f: I0 => Lens[A, Option[B0]]): Aux[A, I0, B0] =
+    new At[A] {
       type I = I0
-      type A = A0
-      def at(index: I0): Lens[S, Option[A0]] = f(index)
+      type B = B0
+      def at(index: I0): Lens[A, Option[B0]] = f(index)
     }
 
   implicit def map[K, V]: Aux[Map[K, V], K, V] =
@@ -27,15 +27,13 @@ object At {
         optA match {
           case None    => map - key
           case Some(a) => map + (key -> a)
-        }
-      )
-    )
+      }))
 
   implicit def set[A]: Aux[Set[A], A, Unit] =
     apply((key: A) =>
-      Lens[Set[A], Option[Unit]](set => if(set.contains(key)) Some(()) else None){
-        case (set, None) => set - key
+      Lens[Set[A], Option[Unit]](set =>
+        if (set.contains(key)) Some(()) else None) {
+        case (set, None)    => set - key
         case (set, Some(_)) => set + key
-      }
-    )
+    })
 }

--- a/kernel/shared/src/main/scala/monocle/function/Cons.scala
+++ b/kernel/shared/src/main/scala/monocle/function/Cons.scala
@@ -2,33 +2,33 @@ package monocle.function
 
 import monocle.{Lens, Optional, Prism}
 
+trait Cons[A] {
+  type B
 
-trait Cons[S] {
-  type A
+  def cons: Prism[A, (B, A)]
 
-  def cons: Prism[S, (A, S)]
-
-  def headOption: Optional[S, A] = cons composeLens Lens.first
-  def tailOption: Optional[S, S] = cons composeLens Lens.second
+  def headOption: Optional[A, B] = cons composeLens Lens.first
+  def tailOption: Optional[A, A] = cons composeLens Lens.second
 }
 
 object Cons {
-  type Aux[S, A0] = Cons[S] { type A = A0 }
+  type Aux[A, B0] = Cons[A] { type B = B0 }
 
-  def apply[S, A0](prism: Prism[S, (A0, S)]): Aux[S, A0] =
-    new Cons[S] {
-      type A = A0
-      def cons: Prism[S, (A0, S)] = prism
+  def apply[A, B0](prism: Prism[A, (B0, A)]): Aux[A, B0] =
+    new Cons[A] {
+      type B = B0
+      def cons: Prism[A, (B0, A)] = prism
     }
 
   implicit def list[A]: Cons[List[A]] =
-    apply(Prism[List[A], (A, List[A])]{
+    apply(Prism[List[A], (A, List[A])] {
       case Nil     => None
       case x :: xs => Some((x, xs))
-    }{ case (x, xs) => x :: xs })
+    } { case (x, xs) => x :: xs })
 
   implicit def vector[A]: Cons[Vector[A]] =
-    apply(Prism[Vector[A], (A, Vector[A])](xs =>
-      xs.headOption.map(_ -> xs.tail)
-    ){ case (x, xs) => x +: xs })
+    apply(
+      Prism[Vector[A], (A, Vector[A])](xs => xs.headOption.map(_ -> xs.tail)) {
+        case (x, xs) => x +: xs
+      })
 }

--- a/kernel/shared/src/main/scala/monocle/function/Field.scala
+++ b/kernel/shared/src/main/scala/monocle/function/Field.scala
@@ -2,43 +2,46 @@ package monocle.function
 
 import monocle.Lens
 
-trait Field1[S] {
-  type A
-  def first: Lens[S, A]
+trait Field1[A] {
+  type B
+  def first: Lens[A, B]
 }
 
 object Field1 {
-  type Aux[S, A0] = Field1[S] { type A = A0 }
+  type Aux[A, B0] = Field1[A] { type B = B0 }
 
-  def apply[S, A0](lens: Lens[S, A0]): Aux[S, A0] = new Field1[S] {
-    type A = A0
-    override val first: Lens[S, A] = lens
+  def apply[A, B0](lens: Lens[A, B0]): Aux[A, B0] = new Field1[A] {
+    type B = B0
+    override val first: Lens[A, B0] = lens
   }
 
   implicit def tuple2[A1, A2]: Aux[(A1, A2), A1] =
-    apply(Lens[(A1, A2), A1](_._1){ case ((_, a2), a1) => (a1, a2) })
+    apply(Lens[(A1, A2), A1](_._1) { case ((_, a2), a1) => (a1, a2) })
 
   implicit def tuple3[A1, A2, A3]: Aux[(A1, A2, A3), A1] =
-    apply(Lens[(A1, A2, A3), A1](_._1){ case ((_, a2, a3), a1) => (a1, a2, a3) })
+    apply(Lens[(A1, A2, A3), A1](_._1) {
+      case ((_, a2, a3), a1) => (a1, a2, a3)
+    })
 }
 
-
-trait Field2[S] {
-  type A
-  def second: Lens[S, A]
+trait Field2[A] {
+  type B
+  def second: Lens[A, B]
 }
 
 object Field2 {
-  type Aux[S, A0] = Field2[S] { type A = A0 }
+  type Aux[A, B0] = Field2[A] { type B = B0 }
 
-  def apply[S, A0](lens: Lens[S, A0]): Aux[S, A0] = new Field2[S] {
-    type A = A0
-    override val second: Lens[S, A] = lens
+  def apply[A, B0](lens: Lens[A, B0]): Aux[A, B0] = new Field2[A] {
+    type B = B0
+    override val second: Lens[A, B0] = lens
   }
 
   implicit def tuple2[A1, A2]: Aux[(A1, A2), A2] =
-    apply(Lens[(A1, A2), A2](_._2){ case ((a1, _), a2) => (a1, a2) })
+    apply(Lens[(A1, A2), A2](_._2) { case ((a1, _), a2) => (a1, a2) })
 
   implicit def tuple3[A1, A2, A3]: Aux[(A1, A2, A3), A2] =
-    apply(Lens[(A1, A2, A3), A2](_._2){ case ((a1, _, a3), a2) => (a1, a2, a3) })
+    apply(Lens[(A1, A2, A3), A2](_._2) {
+      case ((a1, _, a3), a2) => (a1, a2, a3)
+    })
 }

--- a/kernel/shared/src/main/scala/monocle/function/Index.scala
+++ b/kernel/shared/src/main/scala/monocle/function/Index.scala
@@ -4,38 +4,40 @@ import monocle.Optional
 
 import scala.util.Try
 
-trait Index[S] {
+trait Index[A] {
   type I
-  type A
+  type B
 
-  def index(index: I): Optional[S, A]
+  def index(index: I): Optional[A, B]
 }
 
 object Index {
-  type Aux[S, I0, A0] = Index[S] { type I = I0; type A = A0 }
+  type Aux[A, I0, B0] = Index[A] { type I = I0; type B = B0 }
 
-  def apply[S, I0, A0](f : I0 => Optional[S, A0]): Aux[S, I0, A0] =
-    new Index[S] {
+  def apply[A, I0, B0](f: I0 => Optional[A, B0]): Aux[A, I0, B0] =
+    new Index[A] {
       type I = I0
-      type A = A0
-      def index(index: I0): Optional[S, A0] = f(index)
+      type B = B0
+      def index(index: I0): Optional[A, B0] = f(index)
     }
 
   implicit def list[A]: Aux[List[A], Int, A] =
-    apply((i: Int) =>
-      if (i < 0)
-        Optional.void
-      else
-        Optional[List[A], A](xs => Try(xs(i)).toOption)((xs, a) => Try(xs.updated(i, a)).getOrElse(xs))
-    )
+    apply(
+      (i: Int) =>
+        if (i < 0)
+          Optional.void
+        else
+          Optional[List[A], A](xs => Try(xs(i)).toOption)((xs, a) =>
+            Try(xs.updated(i, a)).getOrElse(xs)))
 
   implicit def vector[A]: Aux[Vector[A], Int, A] =
-    apply((i: Int) =>
-      if (i < 0)
-        Optional.void
-      else
-        Optional[Vector[A], A](xs => Try(xs(i)).toOption)((xs, a) => Try(xs.updated(i, a)).getOrElse(xs))
-    )
+    apply(
+      (i: Int) =>
+        if (i < 0)
+          Optional.void
+        else
+          Optional[Vector[A], A](xs => Try(xs(i)).toOption)((xs, a) =>
+            Try(xs.updated(i, a)).getOrElse(xs)))
 
   implicit def map[K, V]: Aux[Map[K, V], K, V] = At.map
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,4 @@
 addSbtPlugin("com.eed3si9n"       % "sbt-unidoc"                    % "0.4.2")
-addSbtPlugin("com.github.gseitz"  % "sbt-release"                   % "1.0.11")
 addSbtPlugin("com.geirsson"       % "sbt-ci-release"                % "1.4.31")
 addSbtPlugin("com.typesafe"       % "sbt-mima-plugin"               % "0.6.0")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh"                       % "0.3.7")


### PR DESCRIPTION
I believe it is more idiomatic to use `A`, `B`, `C` or `A1`, `A2`, `A3` depending on the case. `S` comes from haskell lens `Lens S T A B` but we don't have to conform to it.