### PR TITLE
Missing instance of Index for ListMap

### DIFF
--- a/core/shared/src/main/scala/monocle/function/Index.scala
+++ b/core/shared/src/main/scala/monocle/function/Index.scala
@@ -3,7 +3,7 @@ package monocle.function
 import monocle.{Iso, Optional}
 
 import scala.annotation.{implicitNotFound, tailrec}
-import scala.collection.immutable.SortedMap
+import scala.collection.immutable.{ListMap, SortedMap}
 import scala.util.Try
 
 /**
@@ -49,6 +49,8 @@ object Index extends IndexFunctions with IndexInstancesScalaVersionSpecific {
     else
       Optional[List[A], A](_.drop(i).headOption)(a => s => Try(s.updated(i, a)).getOrElse(s))
   )
+
+  implicit def listMapIndex[K, V]: Index[ListMap[K, V], K, V] = fromAt
 
   implicit def mapIndex[K, V]: Index[Map[K, V], K, V] = fromAt
 

--- a/test/shared/src/test/scala/monocle/function/IndexSpec.scala
+++ b/test/shared/src/test/scala/monocle/function/IndexSpec.scala
@@ -1,12 +1,19 @@
 package monocle.function
 
+import cats.kernel.Eq
 import monocle.MonocleSuite
 import monocle.law.discipline.function.IndexTests
 
+import scala.collection.immutable.ListMap
+
 class IndexSpec extends MonocleSuite {
+
+  implicit val eqListMap: Eq[ListMap[Int, String]] = Eq.fromUniversalEquals
 
   implicit def mmapIndex[K, V]: Index[MMap[K, V], K, V] = Index.fromIso(MMap.toMap)
 
   checkAll("fromIso", IndexTests[MMap[Int, String], Int, String])
+
+  checkAll("ListMap", IndexTests[ListMap[Int, String], Int, String])
 
 }


### PR DESCRIPTION
This adds a missing instance of `Index` for `ListMap` and should fix compilation errors like the one below.

```
[error] ...: ambiguous implicit values:
[error]  both method mapIndex in object Index of type [K, V]=> monocle.function.Index[Map[K,V],K,V]
[error]  and method sortedMapIndex in object Index of type [K, V]=> monocle.function.Index[scala.collection.immutable.SortedMap[K,V],K,V]
[error]  match expected type monocle.function.Index[S,String,A]
```
