### PR TITLE
Fix chained field selection in macro

### DIFF
--- a/macro/src/main/scala/monocle/macros/internal/Macro.scala
+++ b/macro/src/main/scala/monocle/macros/internal/Macro.scala
@@ -44,8 +44,8 @@ private[macros] class MacroImpl(val c: blackbox.Context) {
         )
       ) if termDefName.decodedName.toString == termUseName.decodedName.toString =>
         c.Expr[Lens[A, B]](
-          typesFields.map{ case (t,f) => q"monocle.macros.GenLens[$t](_.$f)" }
-                     .reduce((a,b) => q"$a composeLens $b")
+          typesFields.map{ case (t,f) => q"_root_.monocle.macros.GenLens[$t](_.$f)" }
+                     .reduce((a,b) => q"$a compose $b")
         )
 
       case _ => c.abort(c.enclosingPosition, s"Illegal field reference ${show(field.tree)}; please use _.field1.field2... instead")

--- a/macro/src/test/scala/monocle/LensGenSpec.scala
+++ b/macro/src/test/scala/monocle/LensGenSpec.scala
@@ -14,12 +14,12 @@ class LensGenSpec extends AnyFunSuite with Matchers {
 
   test("GenLens") {
     GenLens[Foo](_.i).get(foo) shouldEqual foo.i
-//    GenLens[Foo](_.bar.b).get(foo) shouldEqual foo.bar.b
+    GenLens[Foo](_.bar.b).get(foo) shouldEqual foo.bar.b
   }
 
   test("fields") {
     foo.optic.field(_.i).get shouldEqual foo.i
-//    foo.optic.field(_.bar.b).get shouldEqual foo.bar.b
+    foo.optic.field(_.bar.b).get shouldEqual foo.bar.b
     foo.optic.field(_.bar).field(_.b).get shouldEqual foo.bar.b
   }
 


### PR DESCRIPTION
Small fix to the GenLens macro to support `_.foo.bar`.

The generated code now calls `Lens#compose` (which returns a `Lens`) instead of `Optional#composeLens` (which returns an `Optional`).