### PR TITLE
Add PTraversal.parModifyF

### DIFF
--- a/core/shared/src/main/scala/monocle/Traversal.scala
+++ b/core/shared/src/main/scala/monocle/Traversal.scala
@@ -1,6 +1,6 @@
 package monocle
 
-import cats.{Applicative, Functor, Id, Monoid, Traverse}
+import cats.{Applicative, Functor, Id, Monoid, Parallel, Traverse}
 import cats.arrow.Choice
 import cats.data.Const
 import cats.instances.int._
@@ -95,6 +95,14 @@ abstract class PTraversal[S, T, A, B] extends Serializable { self =>
           s1 => Functor[F].map(other.modifyF(f)(s1))(Either.right)
         )
     }
+
+  /**
+   * [[PTraversal.modifyF]] for a `Parallel` applicative functor.
+   */
+  @inline final def parModifyF[F[_]](f: A => F[B])(s: S)(implicit F: Parallel[F]): F[T] =
+    F.sequential(
+      modifyF(a => F.parallel(f(a)))(s)(F.applicative)
+    )
 
   /****************************************************************/
   /** Compose methods between a [[PTraversal]] and another Optics */

--- a/test/shared/src/test/scala/monocle/TraversalSpec.scala
+++ b/test/shared/src/test/scala/monocle/TraversalSpec.scala
@@ -7,6 +7,7 @@ import org.scalacheck.Arbitrary.arbitrary
 
 import cats.Eq
 import cats.arrow.{Category, Choice, Compose}
+import cats.syntax.either._
 
 class TraversalSpec extends MonocleSuite {
 
@@ -138,4 +139,9 @@ class TraversalSpec extends MonocleSuite {
     eachLi.modify(_ + 1)(List(1,2,3,4)) shouldEqual List(2,3,4,5)
   }
 
+  test("parModifyF") {
+    eachLi.parModifyF[Either[Unit, *]](i => (i + 1).asRight[Unit])(List(1,2,3,4)) shouldEqual Right(List(2,3,4,5))
+    // `Left` values should be accumulated through `Validated`.
+    eachLi.parModifyF[Either[String, *]](_.toString.asLeft[Int])(List(1,2,3,4)) shouldEqual Left("1234")
+  }
 }


### PR DESCRIPTION
This relates to `PTraversal.modifyF` like `Parallel.parTraverse` relates to `Traverse.traverse`.

It's easy to define `parModifyF` for `PLenses`, `PPrism`s and `POptional`s, but I don't see the need for it yet.