### PR TITLE
Fix spelling typos

### DIFF
--- a/core/shared/src/main/scala/monocle/std/BigDecimal.scala
+++ b/core/shared/src/main/scala/monocle/std/BigDecimal.scala
@@ -12,6 +12,6 @@ trait BigDecimalOptics {
 
   // bigDecimalToDouble cannot be a Prism: some doubles loose precision when converted to a BigDecimal:
   // new java.math.BigDecimal(-2.147483649E-1634, MathContext.UNLIMITED) => java.math.BigDecimal = 0
-  // Also, only a subset of the BigDecimal can be represented as a Double without loosing precision (see BigDecimal.isExactDouble)
+  // Also, only a subset of the BigDecimal can be represented as a Double without losing precision (see BigDecimal.isExactDouble)
   // Besides, MathContext must be passed when creating the Optic
 }

--- a/docs/src/main/tut/release_notes.md
+++ b/docs/src/main/tut/release_notes.md
@@ -306,7 +306,7 @@ Thanks to all the 14 contributors since [1.2.0-M1](https://github.com/julien-tru
 -   `monocle.macros.GenIso` generates `Iso` for case class with a single accessor
 -   `monocle.macros.GenPrism` generates `Prism` for sealed trait
 -   `@Lenses` now supports case classes with type parameters [see](https://github.com/julien-truffaut/Monocle/blob/697bbf0ca3cbb1e8e8b3a63626fc45dfca3cd3cf/example/src/test/scala/monocle/LensExample.scala#L62)
--   `Lenser` is deprecated, use `GenLens` instead (same functionality but more consistant naming)
+-   `Lenser` is deprecated, use `GenLens` instead (same functionality but more consistent naming)
 
 ### Spark friendly
 -   Optics and type classes extends `Serializable`
@@ -404,7 +404,7 @@ Thanks to all the 14 contributors since [1.2.0-M1](https://github.com/julien-tru
     See [example](../example/src/test/scala/monocle/LensExample.scala#L43)
 -   New constructors for simple optics with better type inference, see [example](../test/src/test/scala/monocle/LensSpec.scala#L13-L16)
 -   implicit not found annotations have been added to polymorphic optics to help user figuring out which import is missing
--   `monocle.scalaz.Either` has been renamed `monocle.scalaz.Disjunction` to avoid clashes wih `monocle.std.Either`
+-   `monocle.scalaz.Either` has been renamed `monocle.scalaz.Disjunction` to avoid clashes with `monocle.std.Either`
 -   Add `Each`, `Index`, `Field1`, `Head`, `Tail` and `LastOption` instances for `scalaz.OneAnd`
 -   Add `Each`, `HeadOption`, and `LastOption` for `scala.Some`
 


### PR DESCRIPTION
Should be non-semantic.

Uses https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines to find likely typos.