### PR TITLE
Check scalafmt directly with sbt

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -12,10 +12,8 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
-      - name: Checking code formatting
-        uses: openlawteam/scalafmt-ci@v2
-        with:
-          args: "core dotSyntax macro --exclude=third_party --list"
+      - name: Checking your code format
+        run: sbt scalafmtCheck
       - name: Run tests
         run: |
           sbt +monocleJVM/test +monocleJS/test packageSrc


### PR DESCRIPTION
It is better to use sbt directly to check for format correctness. The action I used earlier is not actively maintained
This version uses sbt and maybe a bit slower but will support upgrades better