### PR TITLE
Friendly type paramaters

### DIFF
--- a/core/shared/src/main/scala/monocle/Fold.scala
+++ b/core/shared/src/main/scala/monocle/Fold.scala
@@ -1,9 +1,9 @@
 package monocle
 
-trait Fold[A, B] { self =>
-  def toIterator(from: A): Iterator[B]
+trait Fold[From, To] { self =>
+  def toIterator(from: From): Iterator[To]
 
-  def foldLeft[Z](zero: Z)(f: (Z, B) => Z): A => Z =
+  def foldLeft[Z](zero: Z)(f: (Z, To) => Z): From => Z =
     from => {
       var acc = zero
       val it  = toIterator(from)
@@ -11,60 +11,60 @@ trait Fold[A, B] { self =>
       acc
     }
 
-  final def firstOption(from: A): Option[B] = {
+  def firstOption(from: From): Option[To] = {
     val it = toIterator(from)
     if (it.hasNext) Some(it.next())
     else None
   }
 
-  final def lastOption(from: A): Option[B] = {
-    var acc: Option[B] = None
-    val it             = toIterator(from)
+  def lastOption(from: From): Option[To] = {
+    var acc: Option[To] = None
+    val it              = toIterator(from)
     while (it.hasNext) acc = Some(it.next())
     acc
   }
 
-  final def toList(from: A): List[B] =
+  def toList(from: From): List[To] =
     toIterator(from).toList
 
-  final def find(predicate: B => Boolean): A => Option[B] =
+  def find(predicate: To => Boolean): From => Option[To] =
     toIterator(_).find(predicate)
 
-  final def exist(predicate: B => Boolean): A => Boolean =
+  def exist(predicate: To => Boolean): From => Boolean =
     toIterator(_).exists(predicate)
 
-  final def forAll(predicate: B => Boolean): A => Boolean =
+  def forAll(predicate: To => Boolean): From => Boolean =
     toIterator(_).forall(predicate)
 
-  final def length(from: A): Int =
+  def length(from: From): Int =
     toIterator(from).length
 
-  final def isEmpty(from: A): Boolean =
+  def isEmpty(from: From): Boolean =
     toIterator(from).hasNext
 
-  final def nonEmpty(from: A): Boolean =
+  def nonEmpty(from: From): Boolean =
     !isEmpty(from)
 
-  def map[C](f: B => C): Fold[A, C] =
-    new Fold[A, C] {
-      def toIterator(from: A): Iterator[C] =
+  def map[X](f: To => X): Fold[From, X] =
+    new Fold[From, X] {
+      def toIterator(from: From): Iterator[X] =
         self.toIterator(from).map(f)
     }
 
-  def compose[C](other: Fold[B, C]): Fold[A, C] =
-    new Fold[A, C] {
-      def toIterator(from: A): Iterator[C] =
+  def compose[X](other: Fold[To, X]): Fold[From, X] =
+    new Fold[From, X] {
+      def toIterator(from: From): Iterator[X] =
         self.toIterator(from).flatMap(other.toIterator)
     }
 
-  def asTarget[C](implicit ev: B =:= C): Fold[A, C] =
-    asInstanceOf[Fold[A, C]]
+  def asTarget[X](implicit ev: To =:= X): Fold[From, X] =
+    asInstanceOf[Fold[From, X]]
 }
 
 object Fold {
-  def apply[A, B](_toIterator: A => Iterator[B]): Fold[A, B] =
-    new Fold[A, B] {
-      def toIterator(from: A): Iterator[B] =
+  def apply[From, To](_toIterator: From => Iterator[To]): Fold[From, To] =
+    new Fold[From, To] {
+      def toIterator(from: From): Iterator[To] =
         _toIterator(from)
     }
 

--- a/core/shared/src/main/scala/monocle/Getter.scala
+++ b/core/shared/src/main/scala/monocle/Getter.scala
@@ -1,27 +1,27 @@
 package monocle
 
-trait Getter[A, B] extends Fold[A, B] { self =>
-  def get(from: A): B
+trait Getter[From, To] extends Fold[From, To] { self =>
+  def get(from: From): To
 
-  final override def toIterator(from: A): Iterator[B] =
+  override def toIterator(from: From): Iterator[To] =
     collection.Iterator.single(get(from))
 
-  final override def map[C](f: B => C): Getter[A, C] =
-    new Getter[A, C] {
-      def get(from: A): C = f(self.get(from))
+  override def map[X](f: To => X): Getter[From, X] =
+    new Getter[From, X] {
+      def get(from: From): X = f(self.get(from))
     }
 
-  def compose[C](other: Getter[B, C]): Getter[A, C] =
-    new Getter[A, C] {
-      def get(from: A): C = other.get(self.get(from))
+  def compose[X](other: Getter[To, X]): Getter[From, X] =
+    new Getter[From, X] {
+      def get(from: From): X = other.get(self.get(from))
     }
 
-  override def asTarget[C](implicit ev: B =:= C): Getter[A, C] =
-    asInstanceOf[Getter[A, C]]
+  override def asTarget[X](implicit ev: To =:= X): Getter[From, X] =
+    asInstanceOf[Getter[From, X]]
 }
 
 object Getter {
-  def apply[A, B](_get: A => B): Getter[A, B] = new Getter[A, B] {
-    def get(from: A): B = _get(from)
+  def apply[From, To](_get: From => To): Getter[From, To] = new Getter[From, To] {
+    def get(from: From): To = _get(from)
   }
 }

--- a/core/shared/src/main/scala/monocle/Iso.scala
+++ b/core/shared/src/main/scala/monocle/Iso.scala
@@ -2,39 +2,39 @@ package monocle
 
 import monocle.function.Reverse
 
-abstract class Iso[A, B] extends Lens[A, B] with Prism[A, B] { self =>
-  override def modify(f: B => B): A => A =
+abstract class Iso[From, To] extends Lens[From, To] with Prism[From, To] { self =>
+  override def modify(f: To => To): From => From =
     from => reverseGet(get(from))
 
-  override def asTarget[C](implicit ev: B =:= C): Iso[A, C] =
-    asInstanceOf[Iso[A, C]]
-
-  def compose[C](other: Iso[B, C]): Iso[A, C] = new Iso[A, C] {
-    def get(from: A): C      = other.get(self.get(from))
-    def reverseGet(to: C): A = self.reverseGet(other.reverseGet(to))
+  def compose[X](other: Iso[To, X]): Iso[From, X] = new Iso[From, X] {
+    def get(from: From): X      = other.get(self.get(from))
+    def reverseGet(to: X): From = self.reverseGet(other.reverseGet(to))
   }
 
-  override def compose[C](other: Lens[B, C]): Lens[A, C] = new Lens[A, C] {
-    def get(from: A): C    = other.get(self.get(from))
-    def set(to: C): A => A = from => self.reverseGet(other.set(to)(self.get(from)))
+  override def compose[X](other: Lens[To, X]): Lens[From, X] = new Lens[From, X] {
+    def get(from: From): X       = other.get(self.get(from))
+    def set(to: X): From => From = from => self.reverseGet(other.set(to)(self.get(from)))
   }
 
-  override def compose[C](other: Prism[B, C]): Prism[A, C] = new Prism[A, C] {
-    def getOption(from: A): Option[C] = other.getOption(self.get(from))
-    def reverseGet(to: C): A          = self.reverseGet(other.reverseGet(to))
+  override def compose[X](other: Prism[To, X]): Prism[From, X] = new Prism[From, X] {
+    def getOption(from: From): Option[X] = other.getOption(self.get(from))
+    def reverseGet(to: X): From          = self.reverseGet(other.reverseGet(to))
   }
+
+  override def asTarget[X](implicit ev: To =:= X): Iso[From, X] =
+    asInstanceOf[Iso[From, X]]
 }
 
 object Iso {
-  def apply[A, B](_get: A => B)(_reverseGet: B => A): Iso[A, B] =
-    new Iso[A, B] {
-      def get(from: A): B      = _get(from)
-      def reverseGet(to: B): A = _reverseGet(to)
+  def apply[From, To](_get: From => To)(_reverseGet: To => From): Iso[From, To] =
+    new Iso[From, To] {
+      def get(from: From): To      = _get(from)
+      def reverseGet(to: To): From = _reverseGet(to)
     }
 
-  def reverse[A, B](implicit ev: Reverse.Aux[A, B]): Iso[A, B] =
+  def reverse[From, To](implicit ev: Reverse.Aux[From, To]): Iso[From, To] =
     ev.reverse
 
-  def id[A]: Iso[A, A] =
-    Iso[A, A](identity)(identity)
+  def id[From]: Iso[From, From] =
+    Iso[From, From](identity)(identity)
 }

--- a/core/shared/src/main/scala/monocle/Lens.scala
+++ b/core/shared/src/main/scala/monocle/Lens.scala
@@ -2,46 +2,46 @@ package monocle
 
 import monocle.function.{At, Field1, Field2, Field3, Field4, Field5, Field6}
 
-trait Lens[A, B] extends Optional[A, B] with Getter[A, B] { self =>
+trait Lens[From, To] extends Optional[From, To] with Getter[From, To] { self =>
 
-  final override def getOption(from: A): Option[B] = Some(get(from))
+  override def getOption(from: From): Option[To] = Some(get(from))
 
-  override def modify(f: B => B): A => A = from => set(f(get(from)))(from)
+  override def modify(f: To => To): From => From = from => set(f(get(from)))(from)
 
-  override def asTarget[C](implicit ev: B =:= C): Lens[A, C] =
-    asInstanceOf[Lens[A, C]]
-
-  def compose[C](other: Lens[B, C]): Lens[A, C] = new Lens[A, C] {
-    def get(from: A): C                    = other.get(self.get(from))
-    def set(to: C): A => A                 = self.modify(other.set(to))
-    override def modify(f: C => C): A => A = self.modify(other.modify(f))
+  def compose[X](other: Lens[To, X]): Lens[From, X] = new Lens[From, X] {
+    def get(from: From): X                       = other.get(self.get(from))
+    def set(to: X): From => From                 = self.modify(other.set(to))
+    override def modify(f: X => X): From => From = self.modify(other.modify(f))
   }
+
+  override def asTarget[X](implicit ev: To =:= X): Lens[From, X] =
+    asInstanceOf[Lens[From, X]]
 }
 
 object Lens {
-  def apply[A, B](_get: A => B)(_set: (A, B) => A): Lens[A, B] = new Lens[A, B] {
-    def get(from: A): B    = _get(from)
-    def set(to: B): A => A = _set(_, to)
+  def apply[From, To](_get: From => To)(_set: (From, To) => From): Lens[From, To] = new Lens[From, To] {
+    def get(from: From): To       = _get(from)
+    def set(to: To): From => From = _set(_, to)
   }
 
-  def at[S, I, A](index: I)(implicit ev: At.Aux[S, I, A]): Lens[S, Option[A]] =
+  def at[From, Index, To](index: Index)(implicit ev: At.Aux[From, Index, To]): Lens[From, Option[To]] =
     ev.at(index)
 
-  def first[S, A](implicit ev: Field1.Aux[S, A]): Lens[S, A] =
+  def first[From, To](implicit ev: Field1.Aux[From, To]): Lens[From, To] =
     ev.first
 
-  def second[S, A](implicit ev: Field2.Aux[S, A]): Lens[S, A] =
+  def second[From, To](implicit ev: Field2.Aux[From, To]): Lens[From, To] =
     ev.second
 
-  def third[S, A](implicit ev: Field3.Aux[S, A]): Lens[S, A] =
+  def third[From, To](implicit ev: Field3.Aux[From, To]): Lens[From, To] =
     ev.third
 
-  def fourth[S, A](implicit ev: Field4.Aux[S, A]): Lens[S, A] =
+  def fourth[From, To](implicit ev: Field4.Aux[From, To]): Lens[From, To] =
     ev.fourth
 
-  def fifth[S, A](implicit ev: Field5.Aux[S, A]): Lens[S, A] =
+  def fifth[From, To](implicit ev: Field5.Aux[From, To]): Lens[From, To] =
     ev.fifth
 
-  def sixth[S, A](implicit ev: Field6.Aux[S, A]): Lens[S, A] =
+  def sixth[From, To](implicit ev: Field6.Aux[From, To]): Lens[From, To] =
     ev.sixth
 }

--- a/core/shared/src/main/scala/monocle/Setter.scala
+++ b/core/shared/src/main/scala/monocle/Setter.scala
@@ -1,23 +1,23 @@
 package monocle
 
-trait Setter[A, B] { self =>
-  def set(to: B): A => A
+trait Setter[From, To] { self =>
+  def set(to: To): From => From
 
-  def modify(f: B => B): A => A
+  def modify(f: To => To): From => From
 
-  def compose[C](other: Setter[B, C]): Setter[A, C] =
-    new Setter[A, C] {
-      def set(to: C): A => A        = self.modify(other.set(to))
-      def modify(f: C => C): A => A = self.modify(other.modify(f))
+  def compose[X](other: Setter[To, X]): Setter[From, X] =
+    new Setter[From, X] {
+      def set(to: X): From => From        = self.modify(other.set(to))
+      def modify(f: X => X): From => From = self.modify(other.modify(f))
     }
 
-  def asTarget[C](implicit ev: B =:= C): Setter[A, C] =
-    asInstanceOf[Setter[A, C]]
+  def asTarget[X](implicit ev: To =:= X): Setter[From, X] =
+    asInstanceOf[Setter[From, X]]
 }
 
 object Setter {
-  def apply[A, B](_modify: (B => B) => (A => A)): Setter[A, B] = new Setter[A, B] {
-    def set(to: B): A => A        = modify(_ => to)
-    def modify(f: B => B): A => A = _modify(f)
+  def apply[From, To](_modify: (To => To) => (From => From)): Setter[From, To] = new Setter[From, To] {
+    def set(to: To): From => From         = modify(_ => to)
+    def modify(f: To => To): From => From = _modify(f)
   }
 }

--- a/core/shared/src/main/scala/monocle/function/At.scala
+++ b/core/shared/src/main/scala/monocle/function/At.scala
@@ -3,21 +3,21 @@ package monocle.function
 import monocle.{Lens, Optional}
 import monocle.Prism.some
 
-trait At[A] extends Index[A] {
-  def at(index: I): Lens[A, Option[B]]
+trait At[From] extends Index[From] {
+  def at(index: Index): Lens[From, Option[To]]
 
-  def index(index: I): Optional[A, B] =
+  def index(index: Index): Optional[From, To] =
     at(index) composePrism some
 }
 
 object At {
-  type Aux[A, I0, B0] = At[A] { type I = I0; type B = B0 }
+  type Aux[From, _Index, _To] = At[From] { type Index = _Index; type To = _To }
 
-  def apply[A, I0, B0](f: I0 => Lens[A, Option[B0]]): Aux[A, I0, B0] =
-    new At[A] {
-      type I = I0
-      type B = B0
-      def at(index: I0): Lens[A, Option[B0]] = f(index)
+  def apply[From, _Index, _To](f: _Index => Lens[From, Option[_To]]): Aux[From, _Index, _To] =
+    new At[From] {
+      type Index = _Index
+      type To    = _To
+      def at(index: Index): Lens[From, Option[To]] = f(index)
     }
 
   implicit def map[K, V]: Aux[Map[K, V], K, V] =

--- a/core/shared/src/main/scala/monocle/function/Cons.scala
+++ b/core/shared/src/main/scala/monocle/function/Cons.scala
@@ -2,22 +2,22 @@ package monocle.function
 
 import monocle.{Lens, Optional, Prism}
 
-trait Cons[A] {
-  type B
+trait Cons[From] {
+  type Head
 
-  def cons: Prism[A, (B, A)]
+  def cons: Prism[From, (Head, From)]
 
-  def headOption: Optional[A, B] = cons composeLens Lens.first
-  def tailOption: Optional[A, A] = cons composeLens Lens.second
+  def headOption: Optional[From, Head] = cons composeLens Lens.first
+  def tailOption: Optional[From, From] = cons composeLens Lens.second
 }
 
 object Cons {
-  type Aux[A, B0] = Cons[A] { type B = B0 }
+  type Aux[From, _Head] = Cons[From] { type Head = _Head }
 
-  def apply[A, B0](prism: Prism[A, (B0, A)]): Aux[A, B0] =
-    new Cons[A] {
-      type B = B0
-      def cons: Prism[A, (B0, A)] = prism
+  def apply[From, _Head](prism: Prism[From, (_Head, From)]): Aux[From, _Head] =
+    new Cons[From] {
+      type Head = _Head
+      def cons: Prism[From, (Head, From)] = prism
     }
 
   implicit def list[A]: Cons.Aux[List[A], A] =

--- a/core/shared/src/main/scala/monocle/function/Field.scala
+++ b/core/shared/src/main/scala/monocle/function/Field.scala
@@ -2,17 +2,17 @@ package monocle.function
 
 import monocle.Lens
 
-trait Field1[A] {
-  type B
-  def first: Lens[A, B]
+trait Field1[From] {
+  type To
+  def first: Lens[From, To]
 }
 
 object Field1 {
-  type Aux[A, B0] = Field1[A] { type B = B0 }
+  type Aux[A, _To] = Field1[A] { type To = _To }
 
-  def apply[A, B0](lens: Lens[A, B0]): Aux[A, B0] = new Field1[A] {
-    type B = B0
-    override val first: Lens[A, B0] = lens
+  def apply[From, _To](lens: Lens[From, _To]): Aux[From, _To] = new Field1[From] {
+    type To = _To
+    override val first: Lens[From, _To] = lens
   }
 
   implicit def tuple2[A1, A2]: Aux[(A1, A2), A1] =
@@ -39,17 +39,17 @@ object Field1 {
     })
 }
 
-trait Field2[A] {
-  type B
-  def second: Lens[A, B]
+trait Field2[From] {
+  type To
+  def second: Lens[From, To]
 }
 
 object Field2 {
-  type Aux[A, B0] = Field2[A] { type B = B0 }
+  type Aux[A, _To] = Field2[A] { type To = _To }
 
-  def apply[A, B0](lens: Lens[A, B0]): Aux[A, B0] = new Field2[A] {
-    type B = B0
-    override val second: Lens[A, B0] = lens
+  def apply[From, _To](lens: Lens[From, _To]): Aux[From, _To] = new Field2[From] {
+    type To = _To
+    override val second: Lens[From, _To] = lens
   }
 
   implicit def tuple2[A1, A2]: Aux[(A1, A2), A2] =
@@ -76,17 +76,17 @@ object Field2 {
     })
 }
 
-trait Field3[A] {
-  type B
-  def third: Lens[A, B]
+trait Field3[From] {
+  type To
+  def third: Lens[From, To]
 }
 
 object Field3 {
-  type Aux[A, B0] = Field3[A] { type B = B0 }
+  type Aux[A, _To] = Field3[A] { type To = _To }
 
-  def apply[A, B0](lens: Lens[A, B0]): Aux[A, B0] = new Field3[A] {
-    type B = B0
-    override val third: Lens[A, B] = lens
+  def apply[From, _To](lens: Lens[From, _To]): Aux[From, _To] = new Field3[From] {
+    type To = _To
+    override val third: Lens[From, To] = lens
   }
 
   implicit def tuple3[A1, A2, A3]: Aux[(A1, A2, A3), A3] =
@@ -110,17 +110,17 @@ object Field3 {
     })
 }
 
-trait Field4[A] {
-  type B
-  def fourth: Lens[A, B]
+trait Field4[From] {
+  type To
+  def fourth: Lens[From, To]
 }
 
 object Field4 {
-  type Aux[A, B0] = Field4[A] { type B = B0 }
+  type Aux[A, _To] = Field4[A] { type To = _To }
 
-  def apply[A, B0](lens: Lens[A, B0]): Aux[A, B0] = new Field4[A] {
-    type B = B0
-    override val fourth: Lens[A, B] = lens
+  def apply[From, _To](lens: Lens[From, _To]): Aux[From, _To] = new Field4[From] {
+    type To = _To
+    override val fourth: Lens[From, To] = lens
   }
 
   implicit def tuple4[A1, A2, A3, A4]: Aux[(A1, A2, A3, A4), A4] =
@@ -139,17 +139,17 @@ object Field4 {
     })
 }
 
-trait Field5[A] {
-  type B
-  def fifth: Lens[A, B]
+trait Field5[From] {
+  type To
+  def fifth: Lens[From, To]
 }
 
 object Field5 {
-  type Aux[A, B0] = Field5[A] { type B = B0 }
+  type Aux[A, _To] = Field5[A] { type To = _To }
 
-  def apply[A, B0](lens: Lens[A, B0]): Aux[A, B0] = new Field5[A] {
-    type B = B0
-    override val fifth: Lens[A, B] = lens
+  def apply[From, _To](lens: Lens[From, _To]): Aux[From, _To] = new Field5[From] {
+    type To = _To
+    override val fifth: Lens[From, To] = lens
   }
 
   implicit def tuple5[A1, A2, A3, A4, A5]: Aux[(A1, A2, A3, A4, A5), A5] =
@@ -163,17 +163,17 @@ object Field5 {
     })
 }
 
-trait Field6[A] {
-  type B
-  def sixth: Lens[A, B]
+trait Field6[From] {
+  type To
+  def sixth: Lens[From, To]
 }
 
 object Field6 {
-  type Aux[A, B0] = Field6[A] { type B = B0 }
+  type Aux[A, _To] = Field6[A] { type To = _To }
 
-  def apply[A, B0](lens: Lens[A, B0]): Aux[A, B0] = new Field6[A] {
-    type B = B0
-    override val sixth: Lens[A, B] = lens
+  def apply[From, _To](lens: Lens[From, _To]): Aux[From, _To] = new Field6[From] {
+    type To = _To
+    override val sixth: Lens[From, To] = lens
   }
 
   implicit def tuple6[A1, A2, A3, A4, A5, A6]: Aux[(A1, A2, A3, A4, A5, A6), A6] =

--- a/core/shared/src/main/scala/monocle/function/Index.scala
+++ b/core/shared/src/main/scala/monocle/function/Index.scala
@@ -4,21 +4,21 @@ import monocle.Optional
 
 import scala.util.Try
 
-trait Index[A] {
-  type I
-  type B
+trait Index[From] {
+  type Index
+  type To
 
-  def index(index: I): Optional[A, B]
+  def index(index: Index): Optional[From, To]
 }
 
 object Index {
-  type Aux[A, I0, B0] = Index[A] { type I = I0; type B = B0 }
+  type Aux[From, _Index, _To] = Index[From] { type Index = _Index; type To = _To }
 
-  def apply[A, I0, B0](f: I0 => Optional[A, B0]): Aux[A, I0, B0] =
-    new Index[A] {
-      type I = I0
-      type B = B0
-      def index(index: I0): Optional[A, B0] = f(index)
+  def apply[From, _Index, _To](f: _Index => Optional[From, _To]): Aux[From, _Index, _To] =
+    new Index[From] {
+      type Index = _Index
+      type To    = _To
+      def index(index: _Index): Optional[From, _To] = f(index)
     }
 
   implicit def list[A]: Aux[List[A], Int, A] =

--- a/core/shared/src/main/scala/monocle/function/Possible.scala
+++ b/core/shared/src/main/scala/monocle/function/Possible.scala
@@ -2,18 +2,18 @@ package monocle.function
 
 import monocle.{Optional, Prism}
 
-trait Possible[A] {
-  type B
+trait Possible[From] {
+  type To
 
-  def possible: Optional[A, B]
+  def possible: Optional[From, To]
 }
 
 object Possible {
-  type Aux[A, B0] = Possible[A] { type B = B0 }
+  type Aux[From, _To] = Possible[From] { type To = _To }
 
-  def apply[A, B0](optional: Optional[A, B0]): Aux[A, B0] = new Possible[A] {
-    type B = B0
-    override val possible: Optional[A, B0] = optional
+  def apply[From, _To](optional: Optional[From, _To]): Aux[From, _To] = new Possible[From] {
+    type To = _To
+    val possible: Optional[From, _To] = optional
   }
 
   implicit def optionPossible[A]: Aux[Option[A], A] =

--- a/core/shared/src/main/scala/monocle/function/Reverse.scala
+++ b/core/shared/src/main/scala/monocle/function/Reverse.scala
@@ -2,21 +2,21 @@ package monocle.function
 
 import monocle.Iso
 
-trait Reverse[A] {
-  type B
+trait Reverse[From] {
+  type To
 
-  def reverse: Iso[A, B]
+  def reverse: Iso[From, To]
 }
 
 object Reverse {
-  type Aux[A, B0] = Reverse[A] { type B = B0 }
+  type Aux[From, _To] = Reverse[From] { type To = _To }
 
-  type AuxId[A] = Reverse[A] { type B = A }
+  type AuxId[From] = Reverse[From] { type To = From }
 
-  def apply[A, B0](iso: Iso[A, B0]): Aux[A, B0] =
-    new Reverse[A] {
-      type B = B0
-      def reverse: Iso[A, B0] = iso
+  def apply[From, _To](iso: Iso[From, _To]): Aux[From, _To] =
+    new Reverse[From] {
+      type To = _To
+      def reverse: Iso[From, _To] = iso
     }
 
   implicit def listReverse[A]: AuxId[List[A]] =

--- a/dotSyntax/src/main/scala/monocle/syntax/AppliedFold.scala
+++ b/dotSyntax/src/main/scala/monocle/syntax/AppliedFold.scala
@@ -3,41 +3,41 @@ package monocle.syntax
 import monocle.function._
 import monocle.{Fold, Prism}
 
-trait AppliedFold[A, B] {
-  def value: A
-  def optic: Fold[A, B]
+trait AppliedFold[From, To] {
+  def value: From
+  def optic: Fold[From, To]
 
-  def map[C](f: B => C): AppliedFold[A, C] =
+  def map[X](f: To => X): AppliedFold[From, X] =
     AppliedFold(value, optic.map(f))
 
-  def compose[C](other: Fold[B, C]): AppliedFold[A, C] =
+  def compose[X](other: Fold[To, X]): AppliedFold[From, X] =
     AppliedFold(value, optic.compose(other))
 
-  def asTarget[C](implicit ev: B =:= C): AppliedFold[A, C] =
-    AppliedFold(value, optic.asTarget[C])
+  def asTarget[X](implicit ev: To =:= X): AppliedFold[From, X] =
+    AppliedFold(value, optic.asTarget[X])
 
-  def toIterator: Iterator[B] =
+  def toIterator: Iterator[To] =
     optic.toIterator(value)
 
-  def foldLeft[Z](zero: Z)(f: (Z, B) => Z): Z =
+  def foldLeft[Z](zero: Z)(f: (Z, To) => Z): Z =
     optic.foldLeft(zero)(f)(value)
 
-  def firstOption: Option[B] =
+  def firstOption: Option[To] =
     optic.firstOption(value)
 
-  def lastOption: Option[B] =
+  def lastOption: Option[To] =
     optic.lastOption(value)
 
-  def toList: List[B] =
+  def toList: List[To] =
     optic.toList(value)
 
-  def find(predicate: B => Boolean): Option[B] =
+  def find(predicate: To => Boolean): Option[To] =
     optic.find(predicate)(value)
 
-  def exist(predicate: B => Boolean): Boolean =
+  def exist(predicate: To => Boolean): Boolean =
     optic.exist(predicate)(value)
 
-  def forAll(predicate: B => Boolean): Boolean =
+  def forAll(predicate: To => Boolean): Boolean =
     optic.forAll(predicate)(value)
 
   def length: Int =
@@ -49,17 +49,17 @@ trait AppliedFold[A, B] {
   def nonEmpty: Boolean =
     optic.nonEmpty(value)
 
-  def at[I, C](i: I)(implicit ev: At.Aux[B, I, C]): AppliedFold[A, Option[C]] =
+  def at[Index, X](i: Index)(implicit ev: At.Aux[To, Index, X]): AppliedFold[From, Option[X]] =
     compose(ev.at(i))
 
-  def some[C](implicit ev: B =:= Option[C]): AppliedFold[A, C] =
-    asTarget[Option[C]].compose(Prism.some[C])
+  def some[X](implicit ev: To =:= Option[X]): AppliedFold[From, X] =
+    asTarget[Option[X]].compose(Prism.some[X])
 }
 
 object AppliedFold {
-  def apply[A, B](_value: A, _optic: Fold[A, B]): AppliedFold[A, B] =
-    new AppliedFold[A, B] {
-      def value: A          = _value
-      def optic: Fold[A, B] = _optic
+  def apply[From, To](_value: From, _optic: Fold[From, To]): AppliedFold[From, To] =
+    new AppliedFold[From, To] {
+      def value: From           = _value
+      def optic: Fold[From, To] = _optic
     }
 }

--- a/dotSyntax/src/main/scala/monocle/syntax/AppliedGetter.scala
+++ b/dotSyntax/src/main/scala/monocle/syntax/AppliedGetter.scala
@@ -3,27 +3,27 @@ package monocle.syntax
 import monocle.Getter
 import monocle.function._
 
-trait AppliedGetter[A, B] extends AppliedFold[A, B] {
-  def value: A
-  def optic: Getter[A, B]
+trait AppliedGetter[From, To] extends AppliedFold[From, To] {
+  def value: From
+  def optic: Getter[From, To]
 
-  def get: B =
+  def get: To =
     optic.get(value)
 
-  def compose[C](other: Getter[B, C]): AppliedGetter[A, C] =
+  def compose[X](other: Getter[To, X]): AppliedGetter[From, X] =
     AppliedGetter(value, optic.compose(other))
 
-  override def asTarget[C](implicit ev: B =:= C): AppliedGetter[A, C] =
-    AppliedGetter(value, optic.asTarget[C])
+  override def asTarget[X](implicit ev: To =:= X): AppliedGetter[From, X] =
+    AppliedGetter(value, optic.asTarget[X])
 
-  override def at[I, C](i: I)(implicit ev: At.Aux[B, I, C]): AppliedGetter[A, Option[C]] =
+  override def at[Index, X](i: Index)(implicit ev: At.Aux[To, Index, X]): AppliedGetter[From, Option[X]] =
     compose(ev.at(i))
 }
 
 object AppliedGetter {
-  def apply[A, B](_value: A, _optic: Getter[A, B]): AppliedGetter[A, B] =
-    new AppliedGetter[A, B] {
-      def value: A            = _value
-      def optic: Getter[A, B] = _optic
+  def apply[From, To](_value: From, _optic: Getter[From, To]): AppliedGetter[From, To] =
+    new AppliedGetter[From, To] {
+      def value: From             = _value
+      def optic: Getter[From, To] = _optic
     }
 }

--- a/dotSyntax/src/main/scala/monocle/syntax/AppliedIso.scala
+++ b/dotSyntax/src/main/scala/monocle/syntax/AppliedIso.scala
@@ -3,30 +3,30 @@ package monocle.syntax
 import monocle.function._
 import monocle.{Iso, Prism}
 
-trait AppliedIso[A, B] extends AppliedLens[A, B] with AppliedPrism[A, B] {
-  def value: A
-  def optic: Iso[A, B]
+trait AppliedIso[From, To] extends AppliedLens[From, To] with AppliedPrism[From, To] {
+  def value: From
+  def optic: Iso[From, To]
 
-  def compose[C](other: Iso[B, C]): AppliedIso[A, C] =
+  def compose[C](other: Iso[To, C]): AppliedIso[From, C] =
     AppliedIso(value, optic.compose(other))
 
-  override def asTarget[C](implicit ev: B =:= C): AppliedIso[A, C] =
-    AppliedIso(value, optic.asTarget[C])
+  override def asTarget[X](implicit ev: To =:= X): AppliedIso[From, X] =
+    AppliedIso(value, optic.asTarget[X])
 
-  override def at[I, C](i: I)(implicit ev: At.Aux[B, I, C]): AppliedLens[A, Option[C]] =
+  override def at[Index, X](i: Index)(implicit ev: At.Aux[To, Index, X]): AppliedLens[From, Option[X]] =
     compose(ev.at(i))
 
-  override def some[C](implicit ev: B =:= Option[C]): AppliedPrism[A, C] =
-    asTarget[Option[C]].compose(Prism.some[C])
+  override def some[X](implicit ev: To =:= Option[X]): AppliedPrism[From, X] =
+    asTarget[Option[X]].compose(Prism.some[X])
 }
 
 object AppliedIso {
-  def apply[A, B](_value: A, _optic: Iso[A, B]): AppliedIso[A, B] =
-    new AppliedIso[A, B] {
-      def value: A         = _value
-      def optic: Iso[A, B] = _optic
+  def apply[From, To](_value: From, _optic: Iso[From, To]): AppliedIso[From, To] =
+    new AppliedIso[From, To] {
+      def value: From          = _value
+      def optic: Iso[From, To] = _optic
     }
 
-  def id[A](value: A): AppliedIso[A, A] =
+  def id[From](value: From): AppliedIso[From, From] =
     apply(value, Iso.id)
 }

--- a/dotSyntax/src/main/scala/monocle/syntax/AppliedLens.scala
+++ b/dotSyntax/src/main/scala/monocle/syntax/AppliedLens.scala
@@ -3,27 +3,27 @@ package monocle.syntax
 import monocle.{Lens, Prism}
 import monocle.function._
 
-trait AppliedLens[A, B] extends AppliedOptional[A, B] with AppliedGetter[A, B] {
-  def value: A
-  def optic: Lens[A, B]
+trait AppliedLens[From, To] extends AppliedOptional[From, To] with AppliedGetter[From, To] {
+  def value: From
+  def optic: Lens[From, To]
 
-  def compose[C](other: Lens[B, C]): AppliedLens[A, C] =
+  def compose[X](other: Lens[To, X]): AppliedLens[From, X] =
     AppliedLens(value, optic.compose(other))
 
-  override def asTarget[C](implicit ev: B =:= C): AppliedLens[A, C] =
-    AppliedLens(value, optic.asTarget[C])
+  override def asTarget[X](implicit ev: To =:= X): AppliedLens[From, X] =
+    AppliedLens(value, optic.asTarget[X])
 
-  override def at[I, C](i: I)(implicit ev: At.Aux[B, I, C]): AppliedLens[A, Option[C]] =
+  override def at[Index, X](i: Index)(implicit ev: At.Aux[To, Index, X]): AppliedLens[From, Option[X]] =
     compose(ev.at(i))
 
-  override def some[C](implicit ev: B =:= Option[C]): AppliedOptional[A, C] =
-    asTarget[Option[C]].compose(Prism.some[C])
+  override def some[X](implicit ev: To =:= Option[X]): AppliedOptional[From, X] =
+    asTarget[Option[X]].compose(Prism.some[X])
 }
 
 object AppliedLens {
-  def apply[A, B](_value: A, _optic: Lens[A, B]): AppliedLens[A, B] =
-    new AppliedLens[A, B] {
-      def value: A          = _value
-      def optic: Lens[A, B] = _optic
+  def apply[From, To](_value: From, _optic: Lens[From, To]): AppliedLens[From, To] =
+    new AppliedLens[From, To] {
+      def value: From           = _value
+      def optic: Lens[From, To] = _optic
     }
 }

--- a/dotSyntax/src/main/scala/monocle/syntax/AppliedOptional.scala
+++ b/dotSyntax/src/main/scala/monocle/syntax/AppliedOptional.scala
@@ -3,36 +3,36 @@ package monocle.syntax
 import monocle.{Optional, Prism}
 import monocle.function._
 
-trait AppliedOptional[A, B] extends AppliedFold[A, B] with AppliedSetter[A, B] {
-  def value: A
-  def optic: Optional[A, B]
+trait AppliedOptional[From, To] extends AppliedFold[From, To] with AppliedSetter[From, To] {
+  def value: From
+  def optic: Optional[From, To]
 
-  def getOption: Option[B] =
+  def getOption: Option[To] =
     optic.getOption(value)
 
-  def set(to: B): A =
+  def set(to: To): From =
     optic.set(to)(value)
 
-  def modify(f: B => B): A =
+  def modify(f: To => To): From =
     optic.modify(f)(value)
 
-  def compose[C](other: Optional[B, C]): AppliedOptional[A, C] =
+  def compose[C](other: Optional[To, C]): AppliedOptional[From, C] =
     AppliedOptional(value, optic.compose(other))
 
-  override def asTarget[C](implicit ev: B =:= C): AppliedOptional[A, C] =
-    AppliedOptional(value, optic.asTarget[C])
+  override def asTarget[X](implicit ev: To =:= X): AppliedOptional[From, X] =
+    AppliedOptional(value, optic.asTarget[X])
 
-  override def at[I, C](i: I)(implicit ev: At.Aux[B, I, C]): AppliedOptional[A, Option[C]] =
+  override def at[Index, X](i: Index)(implicit ev: At.Aux[To, Index, X]): AppliedOptional[From, Option[X]] =
     compose(ev.at(i))
 
-  override def some[C](implicit ev: B =:= Option[C]): AppliedOptional[A, C] =
-    asTarget[Option[C]].compose(Prism.some[C])
+  override def some[X](implicit ev: To =:= Option[X]): AppliedOptional[From, X] =
+    asTarget[Option[X]].compose(Prism.some[X])
 }
 
 object AppliedOptional {
-  def apply[A, B](_value: A, _optic: Optional[A, B]): AppliedOptional[A, B] =
-    new AppliedOptional[A, B] {
-      def value: A              = _value
-      def optic: Optional[A, B] = _optic
+  def apply[From, To](_value: From, _optic: Optional[From, To]): AppliedOptional[From, To] =
+    new AppliedOptional[From, To] {
+      def value: From               = _value
+      def optic: Optional[From, To] = _optic
     }
 }

--- a/dotSyntax/src/main/scala/monocle/syntax/AppliedPrism.scala
+++ b/dotSyntax/src/main/scala/monocle/syntax/AppliedPrism.scala
@@ -2,24 +2,24 @@ package monocle.syntax
 
 import monocle.Prism
 
-trait AppliedPrism[A, B] extends AppliedOptional[A, B] {
-  def value: A
-  def optic: Prism[A, B]
+trait AppliedPrism[From, To] extends AppliedOptional[From, To] {
+  def value: From
+  def optic: Prism[From, To]
 
-  def compose[C](other: Prism[B, C]): AppliedPrism[A, C] =
+  def compose[X](other: Prism[To, X]): AppliedPrism[From, X] =
     AppliedPrism(value, optic.compose(other))
 
-  override def asTarget[C](implicit ev: B =:= C): AppliedPrism[A, C] =
-    AppliedPrism(value, optic.asTarget[C])
+  override def asTarget[X](implicit ev: To =:= X): AppliedPrism[From, X] =
+    AppliedPrism(value, optic.asTarget[X])
 
-  override def some[C](implicit ev: B =:= Option[C]): AppliedPrism[A, C] =
-    asTarget[Option[C]].compose(Prism.some[C])
+  override def some[X](implicit ev: To =:= Option[X]): AppliedPrism[From, X] =
+    asTarget[Option[X]].compose(Prism.some[X])
 }
 
 object AppliedPrism {
-  def apply[A, B](_value: A, _optic: Prism[A, B]): AppliedPrism[A, B] =
-    new AppliedPrism[A, B] {
-      def value: A           = _value
-      def optic: Prism[A, B] = _optic
+  def apply[From, To](_value: From, _optic: Prism[From, To]): AppliedPrism[From, To] =
+    new AppliedPrism[From, To] {
+      def value: From            = _value
+      def optic: Prism[From, To] = _optic
     }
 }

--- a/dotSyntax/src/main/scala/monocle/syntax/AppliedSetter.scala
+++ b/dotSyntax/src/main/scala/monocle/syntax/AppliedSetter.scala
@@ -3,30 +3,30 @@ package monocle.syntax
 import monocle.{Prism, Setter}
 import monocle.function._
 
-trait AppliedSetter[A, B] {
-  def value: A
-  def optic: Setter[A, B]
+trait AppliedSetter[From, To] {
+  def value: From
+  def optic: Setter[From, To]
 
-  def set: B => A =
+  def set: To => From =
     optic.set(_)(value)
 
-  def compose[C](other: Setter[B, C]): AppliedSetter[A, C] =
+  def compose[X](other: Setter[To, X]): AppliedSetter[From, X] =
     AppliedSetter(value, optic.compose(other))
 
-  def asTarget[C](implicit ev: B =:= C): AppliedSetter[A, C] =
-    AppliedSetter(value, optic.asTarget[C])
+  def asTarget[X](implicit ev: To =:= X): AppliedSetter[From, X] =
+    AppliedSetter(value, optic.asTarget[X])
 
-  def at[I, C](i: I)(implicit ev: At.Aux[B, I, C]): AppliedSetter[A, Option[C]] =
+  def at[Index, X](i: Index)(implicit ev: At.Aux[To, Index, X]): AppliedSetter[From, Option[X]] =
     compose(ev.at(i))
 
-  def some[C](implicit ev: B =:= Option[C]): AppliedSetter[A, C] =
-    asTarget[Option[C]].compose(Prism.some[C])
+  def some[X](implicit ev: To =:= Option[X]): AppliedSetter[From, X] =
+    asTarget[Option[X]].compose(Prism.some[X])
 }
 
 object AppliedSetter {
-  def apply[A, B](_value: A, _optic: Setter[A, B]): AppliedSetter[A, B] =
-    new AppliedSetter[A, B] {
-      def value: A            = _value
-      def optic: Setter[A, B] = _optic
+  def apply[From, To](_value: From, _optic: Setter[From, To]): AppliedSetter[From, To] =
+    new AppliedSetter[From, To] {
+      def value: From             = _value
+      def optic: Setter[From, To] = _optic
     }
 }

--- a/dotSyntax/src/main/scala/monocle/syntax/applied.scala
+++ b/dotSyntax/src/main/scala/monocle/syntax/applied.scala
@@ -5,26 +5,26 @@ import monocle.{Fold, Getter, Lens, Optional, Prism, Setter}
 object applied extends AppliedSyntax
 
 trait AppliedSyntax {
-  implicit class AppliedOps[A](value: A) {
-    def optic: AppliedIso[A, A] =
+  implicit class AppliedOps[From](value: From) {
+    def optic: AppliedIso[From, From] =
       AppliedIso.id(value)
 
-    def optic[B](lens: Lens[A, B]): AppliedLens[A, B] =
+    def optic[To](lens: Lens[From, To]): AppliedLens[From, To] =
       AppliedLens(value, lens)
 
-    def optic[B](prism: Prism[A, B]): AppliedPrism[A, B] =
+    def optic[To](prism: Prism[From, To]): AppliedPrism[From, To] =
       AppliedPrism(value, prism)
 
-    def optic[B](optional: Optional[A, B]): AppliedOptional[A, B] =
+    def optic[To](optional: Optional[From, To]): AppliedOptional[From, To] =
       AppliedOptional(value, optional)
 
-    def optic[B](getter: Getter[A, B]): AppliedGetter[A, B] =
+    def optic[To](getter: Getter[From, To]): AppliedGetter[From, To] =
       AppliedGetter(value, getter)
 
-    def optic[B](fold: Fold[A, B]): AppliedFold[A, B] =
+    def optic[To](fold: Fold[From, To]): AppliedFold[From, To] =
       AppliedFold(value, fold)
 
-    def optic[B](setter: Setter[A, B]): AppliedSetter[A, B] =
+    def optic[To](setter: Setter[From, To]): AppliedSetter[From, To] =
       AppliedSetter(value, setter)
   }
 }

--- a/dotSyntax/src/main/scala/monocle/syntax/fold.scala
+++ b/dotSyntax/src/main/scala/monocle/syntax/fold.scala
@@ -6,11 +6,11 @@ import monocle.{Fold, Prism}
 object fold extends FoldSyntax
 
 trait FoldSyntax {
-  implicit class FoldOps[A, B](optic: Fold[A, B]) {
-    def at[I, C](i: I)(implicit ev: At.Aux[B, I, C]): Fold[A, Option[C]] =
+  implicit class FoldOps[From, To](optic: Fold[From, To]) {
+    def at[Index, X](i: Index)(implicit ev: At.Aux[To, Index, X]): Fold[From, Option[X]] =
       optic.compose(ev.at(i))
 
-    def some[C](implicit ev: B =:= Option[C]): Fold[A, C] =
-      optic.asTarget[Option[C]].compose(Prism.some[C])
+    def some[X](implicit ev: To =:= Option[X]): Fold[From, X] =
+      optic.asTarget[Option[X]].compose(Prism.some[X])
   }
 }

--- a/dotSyntax/src/main/scala/monocle/syntax/getter.scala
+++ b/dotSyntax/src/main/scala/monocle/syntax/getter.scala
@@ -6,8 +6,8 @@ import monocle.function._
 object getter extends GetterSyntax
 
 trait GetterSyntax {
-  implicit class GetterOps[A, B](optic: Getter[A, B]) {
-    def at[I, C](i: I)(implicit ev: At.Aux[B, I, C]): Getter[A, Option[C]] =
+  implicit class GetterOps[From, To](optic: Getter[From, To]) {
+    def at[Index, X](i: Index)(implicit ev: At.Aux[To, Index, X]): Getter[From, Option[X]] =
       optic.compose(ev.at(i))
   }
 }

--- a/dotSyntax/src/main/scala/monocle/syntax/iso.scala
+++ b/dotSyntax/src/main/scala/monocle/syntax/iso.scala
@@ -6,11 +6,11 @@ import monocle.{Iso, Lens, Prism}
 object iso extends IsoSyntax
 
 trait IsoSyntax {
-  implicit class IsoOps[A, B](optic: Iso[A, B]) {
-    def at[I, C](i: I)(implicit ev: At.Aux[B, I, C]): Lens[A, Option[C]] =
+  implicit class IsoOps[From, To](optic: Iso[From, To]) {
+    def at[Index, X](i: Index)(implicit ev: At.Aux[To, Index, X]): Lens[From, Option[X]] =
       optic.compose(ev.at(i))
 
-    def some[C](implicit ev: B =:= Option[C]): Prism[A, C] =
-      optic.asTarget[Option[C]].compose(Prism.some[C])
+    def some[X](implicit ev: To =:= Option[X]): Prism[From, X] =
+      optic.asTarget[Option[X]].compose(Prism.some[X])
   }
 }

--- a/dotSyntax/src/main/scala/monocle/syntax/lens.scala
+++ b/dotSyntax/src/main/scala/monocle/syntax/lens.scala
@@ -6,11 +6,11 @@ import monocle.function._
 object lens extends LensSyntax
 
 trait LensSyntax {
-  implicit class LensOps[A, B](optic: Lens[A, B]) {
-    def at[I, C](i: I)(implicit ev: At.Aux[B, I, C]): Lens[A, Option[C]] =
+  implicit class LensOps[From, To](optic: Lens[From, To]) {
+    def at[Index, X](i: Index)(implicit ev: At.Aux[To, Index, X]): Lens[From, Option[X]] =
       optic.compose(ev.at(i))
 
-    def some[C](implicit ev: B =:= Option[C]): Optional[A, C] =
-      optic.asTarget[Option[C]].compose(Prism.some[C])
+    def some[X](implicit ev: To =:= Option[X]): Optional[From, X] =
+      optic.asTarget[Option[X]].compose(Prism.some[X])
   }
 }

--- a/dotSyntax/src/main/scala/monocle/syntax/optional.scala
+++ b/dotSyntax/src/main/scala/monocle/syntax/optional.scala
@@ -6,11 +6,11 @@ import monocle.function._
 object optional extends LensSyntax
 
 trait OptionalSyntax {
-  implicit class OptionalOps[A, B](optic: Optional[A, B]) {
-    def at[I, C](i: I)(implicit ev: At.Aux[B, I, C]): Optional[A, Option[C]] =
+  implicit class OptionalOps[From, To](optic: Optional[From, To]) {
+    def at[Index, X](i: Index)(implicit ev: At.Aux[To, Index, X]): Optional[From, Option[X]] =
       optic.compose(ev.at(i))
 
-    def some[C](implicit ev: B =:= Option[C]): Optional[A, C] =
-      optic.asTarget[Option[C]].compose(Prism.some[C])
+    def some[X](implicit ev: To =:= Option[X]): Optional[From, X] =
+      optic.asTarget[Option[X]].compose(Prism.some[X])
   }
 }

--- a/dotSyntax/src/main/scala/monocle/syntax/prism.scala
+++ b/dotSyntax/src/main/scala/monocle/syntax/prism.scala
@@ -6,11 +6,11 @@ import monocle.{Optional, Prism}
 object prism extends PrismSyntax
 
 trait PrismSyntax {
-  implicit class PrismSyntaxOps[A, B](optic: Prism[A, B]) {
-    def at[I, C](i: I)(implicit ev: At.Aux[B, I, C]): Optional[A, Option[C]] =
+  implicit class PrismSyntaxOps[From, To](optic: Prism[From, To]) {
+    def at[Index, X](i: Index)(implicit ev: At.Aux[To, Index, X]): Optional[From, Option[X]] =
       optic.compose(ev.at(i))
 
-    def some[C](implicit ev: B =:= Option[C]): Prism[A, C] =
-      optic.asTarget[Option[C]].compose(Prism.some[C])
+    def some[X](implicit ev: To =:= Option[X]): Prism[From, X] =
+      optic.asTarget[Option[X]].compose(Prism.some[X])
   }
 }

--- a/dotSyntax/src/main/scala/monocle/syntax/setter.scala
+++ b/dotSyntax/src/main/scala/monocle/syntax/setter.scala
@@ -6,11 +6,11 @@ import monocle.function._
 object setter extends SetterSyntax
 
 trait SetterSyntax {
-  implicit class SetterOps[A, B](optic: Setter[A, B]) {
-    def at[I, C](i: I)(implicit ev: At.Aux[B, I, C]): Setter[A, Option[C]] =
+  implicit class SetterOps[From, To](optic: Setter[From, To]) {
+    def at[Index, X](i: Index)(implicit ev: At.Aux[To, Index, X]): Setter[From, Option[X]] =
       optic.compose(ev.at(i))
 
-    def some[C](implicit ev: B =:= Option[C]): Setter[A, C] =
-      optic.asTarget[Option[C]].compose(Prism.some[C])
+    def some[X](implicit ev: To =:= Option[X]): Setter[From, X] =
+      optic.asTarget[Option[X]].compose(Prism.some[X])
   }
 }

--- a/generic/src/main/scala/monocle/generic/CoProduct.scala
+++ b/generic/src/main/scala/monocle/generic/CoProduct.scala
@@ -36,10 +36,10 @@ trait CoProductInstances {
     * {{{
     *   sealed trait S
     *   case class A(name: String) extends S
-    *   case class B(name: String) extends S
+    *   case class To(name: String) extends S
     *   case class C(otherName: String) extends S
     *
-    *   val iso: Iso[S, Either[A, Either[B, C]]] = coProductToEither[S].apply
+    *   val iso: Iso[S, Either[A, Either[To, C]]] = coProductToEither[S].apply
     * }}}
     */
   def coProductToEither[S]: GenCoProductToEither[S] = new GenCoProductToEither
@@ -77,10 +77,10 @@ trait CoProductInstances {
     * {{{
     *   sealed trait S
     *   case class A(name: String) extends S
-    *   case class B(name: String) extends S
+    *   case class To(name: String) extends S
     *   case class C(otherName: String) extends S
     *
-    *   val iso: Iso[S, Either[A, Either[B, C])] = coProductToDisjunction[S].apply
+    *   val iso: Iso[S, Either[A, Either[To, C])] = coProductToDisjunction[S].apply
     * }}}
     */
   def coProductToDisjunction[S]: GenCoProductToDisjunction[S] = new GenCoProductToDisjunction


### PR DESCRIPTION
This PR renames the type parameters in optics from `A`, `B` to `From` and `To`, e.g.

```scala
trait Lens[From, To] {
  def get(from: From): To
  def set(to: To): From => From
}
```

I believe it should make the code more readable, especially for beginners.
