### PR TITLE
bump mima previos version to 2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 
 scala:
 - 2.12.10
-- 2.13.1
+- 2.13.0
 
 jdk:
 - openjdk8

--- a/build.sbt
+++ b/build.sbt
@@ -112,7 +112,7 @@ lazy val paradisePlugin = Def.setting{
 lazy val kindProjector  = "org.typelevel" % "kind-projector" % "0.11.0" cross CrossVersion.full
 
 def mimaSettings(module: String): Seq[Setting[_]] = mimaDefaultSettings ++ Seq(
-  mimaPreviousArtifacts := Set("com.github.julien-truffaut" %%  (s"monocle-${module}") % "1.6.0")
+  mimaPreviousArtifacts := Set("com.github.julien-truffaut" %%  (s"monocle-${module}") % "2.0.0")
 )
 
 lazy val gitRev = sys.process.Process("git rev-parse HEAD").lineStream_!.head

--- a/build.sbt
+++ b/build.sbt
@@ -53,8 +53,8 @@ def scalaVersionSpecificFolders(srcName: String, srcBaseDir: java.io.File, scala
 }
 
 lazy val buildSettings = Seq(
-  scalaVersion       := "2.13.1",
-  crossScalaVersions := Seq("2.12.10", "2.13.1"),
+  scalaVersion       := "2.13.0",
+  crossScalaVersions := Seq("2.12.10", "2.13.0"),
   scalatestVersion   := "3.2.0-M1",
   resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
   scalacOptions     ++= Seq(


### PR DESCRIPTION
I am trying to verify binary compatibility for https://github.com/julien-truffaut/Monocle/issues/794

I don't understand why mima reports lost of changes in `monocle.std.nev`. As far as I can tell, we haven't changed that file: https://github.com/julien-truffaut/Monocle/compare/v2.0.0...master

here is an example:
```
[error]  * method vectorToNev()monocle.PPrism in object monocle.std.nev has a different signature in current version, where it is <A:Ljava/lang/Object;>()Lmonocle/PPrism<Lscala/collection/immutable/Vector<TA;>;Lscala/collection/immutable/Vector<TA;>;Lcats/data/NonEmptyVector<TA;>;Lcats/data/NonEmptyVector<TA;>;>; rather than <A:Ljava/lang/Object;>()Lmonocle/PPrism<Lscala/collection/immutable/Vector<TA;>;Lscala/collection/immutable/Vector<TA;>;Lscala/collection/immutable/Vector<TA;>;Lscala/collection/immutable/Vector<TA;>;>;
[error]    filter with: ProblemFilters.exclude[IncompatibleSignatureProblem]("monocle.std.nev.vectorToNev")
```