### PR TITLE
Add macro hint for Scala 2.13

### DIFF
--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -26,10 +26,16 @@ libraryDependencies ++= Seq(
 )
 ```
 
-If you want to use macro annotations such as `@Lenses`, you will also need to include:
+If you want to use macro annotations such as `@Lenses`, you will also need to include the following for Scala `2.12`:
 
 ```scala
 addCompilerPlugin("org.scalamacros" %% "paradise" % "2.1.1" cross CrossVersion.full)
+```
+
+On Scala `2.13`, enable the compiler flag `-Ymacro-annotations` instead:
+
+```scala
+scalacOptions in Global += "-Ymacro-annotations"
 ```
 
 ## Motivation


### PR DESCRIPTION
People who are not familiar with macros might wonder why macro paradise doesn't work on 2.13 and what to do instead, so I think it's worth a little hint.