### PR TITLE
Update discipline

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,8 +35,6 @@ inThisBuild(List(
   )
 ))
 
-lazy val scalatestVersion = settingKey[String]("")
-
 // shamelessly copied from cats
 def scalaVersionSpecificFolders(srcName: String, srcBaseDir: java.io.File, scalaVersion: String) = {
   def extraDirs(suffix: String) =
@@ -53,9 +51,8 @@ def scalaVersionSpecificFolders(srcName: String, srcBaseDir: java.io.File, scala
 }
 
 lazy val buildSettings = Seq(
-  scalaVersion       := "2.13.0",
-  crossScalaVersions := Seq("2.12.10", "2.13.0"),
-  scalatestVersion   := "3.2.0-M1",
+  scalaVersion       := "2.13.1",
+  crossScalaVersions := Seq("2.12.10", "2.13.1"),
   resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
   scalacOptions     ++= Seq(
     "-encoding", "UTF-8",
@@ -91,10 +88,8 @@ lazy val shapeless         = Def.setting("com.chuusai"       %%% "shapeless"    
 lazy val refinedDep        = Def.setting("eu.timepit"        %%% "refined"                  % "0.9.12")
 lazy val refinedScalacheck = Def.setting("eu.timepit"        %%% "refined-scalacheck"       % "0.9.12" % "test")
 
-lazy val discipline        = Def.setting("org.typelevel"     %%% "discipline-scalatest"     % "1.0.0-RC2")
-lazy val scalacheck        = Def.setting("org.scalacheck"    %%% "scalacheck"               % "1.14.3")
-lazy val scalatestplus     = Def.setting("org.scalatestplus" %%% "scalatestplus-scalacheck" % "1.0.0-SNAP8" % "test")
-lazy val scalatest         = Def.setting("org.scalatest"     %%% "scalatest"                % scalatestVersion.value % "test")
+lazy val discipline           = Def.setting("org.typelevel"  %%% "discipline-core"          % "1.0.0")
+lazy val discipline_scalatest = Def.setting("org.typelevel"  %%% "discipline-scalatest"     % "1.0.0")
 
 lazy val macroVersion = "2.1.1"
 
@@ -190,7 +185,7 @@ lazy val law = crossProject(JVMPlatform, JSPlatform)
     _.jvmSettings(monocleJvmSettings),
     _.jsSettings(monocleJsSettings)
   )
-  .settings(libraryDependencies ++= Seq(discipline.value, scalacheck.value))
+  .settings(libraryDependencies ++= Seq(discipline.value))
 
 lazy val macros = crossProject(JVMPlatform, JSPlatform)
   .crossType(CrossType.Pure)
@@ -240,7 +235,7 @@ lazy val test = crossProject(JVMPlatform, JSPlatform).dependsOn(core, generic, m
   )
   .settings(noPublishSettings: _*)
   .settings(
-    libraryDependencies ++= Seq(cats.value, catsLaws.value, shapeless.value, scalatest.value, refinedScalacheck.value),
+    libraryDependencies ++= Seq(cats.value, catsLaws.value, shapeless.value, discipline_scalatest.value, refinedScalacheck.value),
     libraryDependencies ++= paradisePlugin.value
   )
 
@@ -259,7 +254,7 @@ lazy val example = project.dependsOn(core.jvm, generic.jvm, refined.jvm, macros.
   .settings(monocleJvmSettings)
   .settings(noPublishSettings)
   .settings(
-    libraryDependencies ++= Seq(cats.value, shapeless.value, scalatest.value),
+    libraryDependencies ++= Seq(cats.value, shapeless.value, discipline_scalatest.value),
     libraryDependencies ++= paradisePlugin.value
   )
 

--- a/example/src/test/scala/other/ImportExample.scala
+++ b/example/src/test/scala/other/ImportExample.scala
@@ -2,7 +2,8 @@ package other
 
 import monocle.TestInstances
 import org.scalatest.funsuite.AnyFunSuite
-import org.typelevel.discipline.scalatest.Discipline
+import org.scalatest.prop.Configuration
+import org.typelevel.discipline.scalatest.FunSuiteDiscipline
 import shapeless.test.illTyped
 import shapeless.{::, HNil}
 import org.scalatest.matchers.should.Matchers
@@ -20,7 +21,7 @@ object Custom {
 }
 
 // Cannot use MonocleSuite as it brings all imports
-class ImportExample extends AnyFunSuite with Discipline with Matchers with TestInstances {
+class ImportExample extends AnyFunSuite with Configuration with FunSuiteDiscipline with Matchers with TestInstances {
 
   test("monocle.function.all._ imports all polymorphic optics in the scope") {
     import monocle.function.all._

--- a/test/shared/src/test/scala-2.12-/monocle/function/PlatedSpec.scala
+++ b/test/shared/src/test/scala-2.12-/monocle/function/PlatedSpec.scala
@@ -8,20 +8,20 @@ import org.scalacheck.Prop._
 class PlatedSpec extends MonocleSuite {
 
   test("children on Stream is consistent with .tail") {
-    check { (h: Int, t: Stream[Int]) =>
+    forAll { (h: Int, t: Stream[Int]) =>
       val s = h #:: t
       children(s) === List(s.tail)
     }
   }
 
   test("universe on Stream is consistent with .tails") {
-    check { (s: Stream[Int]) =>
+    forAll { (s: Stream[Int]) =>
       universe(s) === s.tails.toStream
     }
   }
 
   test("rewrite on Stream is able to change the last node") {
-    check { (x: Int, y: Int, z: Int) =>
+    forAll { (x: Int, y: Int, z: Int) =>
       rewrite[Stream[Int]] {
         case Stream(n) if n != x =>
           Some(Stream(x))
@@ -31,7 +31,7 @@ class PlatedSpec extends MonocleSuite {
   }
 
   test("rewriteOf initOption on Stream is able to change the first node") {
-    check { (x: Int, y: Int, z: Int) =>
+    forAll { (x: Int, y: Int, z: Int) =>
       rewriteOf(initOption[Stream[Int], Int].asSetter) {
         case Stream(n) if n != z => Some(Stream(z))
         case _ => None
@@ -40,7 +40,7 @@ class PlatedSpec extends MonocleSuite {
   }
 
   test("transform on Stream can change the last element without a guard") {
-    check { (i: Int, x: Int, y: Int, xs: Stream[Int]) =>
+    forAll { (i: Int, x: Int, y: Int, xs: Stream[Int]) =>
       transform[Stream[Int]] {
         case Stream(_) => Stream(i)
         case xs => xs
@@ -49,7 +49,7 @@ class PlatedSpec extends MonocleSuite {
   }
 
   test("transform initOption on Stream can change the first element without a guard") {
-    check { (i: Int, x: Int, y: Int, xs: Stream[Int]) =>
+    forAll { (i: Int, x: Int, y: Int, xs: Stream[Int]) =>
       transformOf(initOption[Stream[Int], Int].asSetter) {
         case Stream(_) => Stream(i)
         case xs => xs
@@ -58,7 +58,7 @@ class PlatedSpec extends MonocleSuite {
   }
 
   test("transform counting Stream using Option.pure returns count of changes the same as stream size") {
-    check { (xs: Stream[Int]) =>
+    forAll { (xs: Stream[Int]) =>
       transformCounting[Stream[Int]](Option(_))(xs) === ((xs.size, xs))
     }
   }

--- a/test/shared/src/test/scala/monocle/MonocleSuite.scala
+++ b/test/shared/src/test/scala/monocle/MonocleSuite.scala
@@ -7,11 +7,13 @@ import monocle.state._
 import monocle.std.StdInstances
 import monocle.syntax.Syntaxes
 import org.scalatest.funsuite.AnyFunSuite
-import org.typelevel.discipline.scalatest.Discipline
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.Configuration
+import org.typelevel.discipline.scalatest.FunSuiteDiscipline
 
 trait MonocleSuite extends AnyFunSuite
-                      with Discipline
+                      with Configuration
+                      with FunSuiteDiscipline
                       with Matchers
                       with TestInstances
                       with StdInstances


### PR DESCRIPTION
This PR updates discipline to version 1.0.0 overriding #808 
Some things worth noting:
* discipline_scalatest brings the dependencies on scalatest and scalacheck.
* This versions are compiled for scala.js 1.0.0-RC2 allowing us to get there eventually