### PR TITLE
Use wildcard type instead of whitebox cast in IsoFields

### DIFF
--- a/core/shared/src/main/scala-3/monocle/internal/IsoFields.scala
+++ b/core/shared/src/main/scala-3/monocle/internal/IsoFields.scala
@@ -1,28 +1,23 @@
 package monocle.internal
 
-import monocle.Iso
+import monocle.{Iso, PIso}
 import scala.quoted.{quotes, Expr, Quotes, Type}
 import scala.deriving.Mirror
 
 object IsoFields {
-  transparent inline def apply[S <: Product](using mirror: Mirror.ProductOf[S]): Iso[S, Tuple] =
+  transparent inline def apply[S <: Product](using mirror: Mirror.ProductOf[S]): PIso[S, S, ? <: Tuple, ? <: Tuple] =
     ${ IsoFieldsImpl.apply[S]('mirror) }
 }
 
 private[monocle] object IsoFieldsImpl {
 
-  def apply[S <: Product](mirror: Expr[Mirror.ProductOf[S]])(using Quotes, Type[S]): Expr[Iso[S, Tuple]] = {
-
-    def whitebox[A <: Tuple](e: Expr[Iso[S, A]]): Expr[Iso[S, Tuple]] =
-      e.asInstanceOf[Expr[Iso[S, Tuple]]]
-
+  def apply[S <: Product](mirror: Expr[Mirror.ProductOf[S]])(using Quotes, Type[S]): Expr[PIso[S, S, ? <: Tuple, ? <: Tuple]] =
     mirror match {
       case '{ type a <: Tuple; $m: Mirror.ProductOf[S] { type MirroredElemTypes = `a` } } =>
-        whitebox('{
+        '{
           val f: S => a = Tuple.fromProductTyped(_)(using $m)
           val g: a => S = $m.fromProduct(_)
           Iso[S, a](f)(g)
-        })
+        }
     }
-  }
 }

--- a/core/shared/src/main/scala-3/monocle/internal/IsoFields.scala
+++ b/core/shared/src/main/scala-3/monocle/internal/IsoFields.scala
@@ -19,5 +19,7 @@ private[monocle] object IsoFieldsImpl {
           val g: a => S = $m.fromProduct(_)
           Iso[S, a](f)(g)
         }
+      case other =>
+        quotes.reflect.report.errorAndAbort(s"Unexpected mirror type: ${other.show}")
     }
 }

--- a/core/shared/src/main/scala-3/monocle/internal/IsoFields.scala
+++ b/core/shared/src/main/scala-3/monocle/internal/IsoFields.scala
@@ -11,7 +11,9 @@ object IsoFields {
 
 private[monocle] object IsoFieldsImpl {
 
-  def apply[S <: Product](mirror: Expr[Mirror.ProductOf[S]])(using Quotes, Type[S]): Expr[PIso[S, S, ? <: Tuple, ? <: Tuple]] =
+  def apply[S <: Product](
+    mirror: Expr[Mirror.ProductOf[S]]
+  )(using Quotes, Type[S]): Expr[PIso[S, S, ? <: Tuple, ? <: Tuple]] =
     mirror match {
       case '{ type a <: Tuple; $m: Mirror.ProductOf[S] { type MirroredElemTypes = `a` } } =>
         '{

--- a/core/shared/src/main/scala-3/monocle/syntax/MacroSyntax.scala
+++ b/core/shared/src/main/scala-3/monocle/syntax/MacroSyntax.scala
@@ -13,7 +13,7 @@ trait MacroSyntax {
       * Case classes with 0 fields will correspond with `EmptyTuple`, 1 with `Tuple1[field type]`, 2 or more with a
       * tuple of all field types in the same order as the fields themselves.
       */
-    transparent inline def fields[S <: Product: Mirror.ProductOf]: Iso[S, Tuple] =
+    transparent inline def fields[S <: Product: Mirror.ProductOf]: PIso[S, S, ? <: Tuple, ? <: Tuple] =
       IsoFields[S]
   }
 

--- a/core/shared/src/test/scala-3/monocle/internal/IsoFieldsTest.scala
+++ b/core/shared/src/test/scala-3/monocle/internal/IsoFieldsTest.scala
@@ -31,4 +31,13 @@ final class IsoFieldsTest extends munit.FunSuite {
     assertEquals(iso.reverseGet(("hi", 5)), Foo("hi", 5))
     assertEquals(iso.reverseGet(iso.get(Foo("hi", 5))), Foo("hi", 5))
   }
+
+  test("fields extension method works") {
+    case class Foo(s: String, i: Int)
+    val foo = Foo("hi", 5)
+    val iso: Iso[Foo, (String, Int)] = Iso.fields[Foo]
+
+    assertEquals(iso.get(foo), ("hi", 5))
+    assertEquals(iso.reverseGet(("hi", 5)), foo)
+  }
 }

--- a/core/shared/src/test/scala-3/monocle/internal/IsoFieldsTest.scala
+++ b/core/shared/src/test/scala-3/monocle/internal/IsoFieldsTest.scala
@@ -34,7 +34,7 @@ final class IsoFieldsTest extends munit.FunSuite {
 
   test("fields extension method works") {
     case class Foo(s: String, i: Int)
-    val foo = Foo("hi", 5)
+    val foo                          = Foo("hi", 5)
     val iso: Iso[Foo, (String, Int)] = Iso.fields[Foo]
 
     assertEquals(iso.get(foo), ("hi", 5))


### PR DESCRIPTION
Replace the `whitebox` cast (`asInstanceOf[Expr[Iso[S, Tuple]]]`) with a wildcard return type using `PIso[S, S, ? <: Tuple, ? <: Tuple]`.

Since `IsoFields.apply` is a `transparent inline` method, the compiler still infers the precise tuple type at call sites. This avoids the unsafe cast.

The motivation is to prepare for future stricter checks in the Scala 3 compiler (https://github.com/scala/scala3/pull/25756). The current implementation exploits a missing check to generate an unsound cast.

Note: we use `PIso` (a trait) directly instead of the `Iso` type alias (defined as `type Iso[S, A] = PIso[S, S, A, A]`) because Scala 3 cannot reduce higher-kinded type aliases applied to wildcard arguments. Is that acceptable to use `PIso` instead of `Iso`?