### PR TITLE
fix(std): reject "-0" forms in stringToLong (#1582)

### DIFF
--- a/core/shared/src/main/scala/monocle/std/String.scala
+++ b/core/shared/src/main/scala/monocle/std/String.scala
@@ -36,8 +36,10 @@ trait StringOptics extends PlatformSpecificStringOptics {
     // we reject cases where String will be an invalid Prism according 2nd Prism law
     // * String starts with +
     // * String starts with 0 and has multiple digits
+    // * String starts with -0 (negative zero forms never round-trip)
     def inputBreaksPrismLaws(input: String): Boolean =
-      s.isEmpty || s.startsWith("+") || (s.startsWith("0") && s.length > 1)
+      s.isEmpty || s.startsWith("+") || (s.startsWith("0") && s.length > 1) ||
+        (s.length > 1 && s.charAt(0) == '-' && s.charAt(1) == '0')
 
     if (inputBreaksPrismLaws(s)) None
     else

--- a/test/shared/src/test/scala/monocle/std/StringsSpec.scala
+++ b/test/shared/src/test/scala/monocle/std/StringsSpec.scala
@@ -25,4 +25,17 @@ class StringsSpec extends MonocleSuite {
   // checkAll("String to URI", PrismTests(stringToURI))
 
   checkAll("plated String", TraversalTests(plate[String]))
+
+  // see #1582: "-0" et al. parsed to 0L but reverseGet round-tripped to "0"
+  test("stringToLong rejects negative-zero forms") {
+    assertEquals(stringToLong.getOption("-0"), None)
+    assertEquals(stringToLong.getOption("-00"), None)
+    assertEquals(stringToLong.getOption("-01"), None)
+  }
+
+  test("stringToLong still accepts ordinary negatives and zero") {
+    assertEquals(stringToLong.getOption("0"), Some(0L))
+    assertEquals(stringToLong.getOption("-1"), Some(-1L))
+    assertEquals(stringToLong.getOption("-10"), Some(-10L))
+  }
 }


### PR DESCRIPTION
Fixes #1582. `stringToLong.getOption("-0")` returned `Some(0L)` but `reverseGet(0L)` is `"0"`, so the Prism round-trip law fails for negative-zero forms (`-0`, `-00`, `-01`, ...). Extend `inputBreaksPrismLaws` with a guard for any string starting with `-0`.

Per @julien-truffaut in https://github.com/optics-dev/Monocle/issues/1582#issuecomment-4419013010 ("Thanks for the bug report ... Feel free to send a PR :)"), with the guard expression matching the suggestion in the issue. Added unit tests in `StringsSpec` for both the rejected and the still-accepted shapes.