### PR TITLE
Fix Scala 3 compile error in GenIso after IsoFields return type change

### DIFF
--- a/macro/src/main/scala-3/monocle/macros/GenIso.scala
+++ b/macro/src/main/scala-3/monocle/macros/GenIso.scala
@@ -74,7 +74,7 @@ object GenIso {
         whitebox(_apply[S, a](e))
 
       case _ =>
-        whitebox('{ monocle.internal.IsoFields[S](using $e) })
+        '{ monocle.internal.IsoFields[S](using $e) }.asInstanceOf[Expr[Iso[S, Any]]]
     }
   }
 }


### PR DESCRIPTION
PR #1574 changed IsoFields.apply to return
PIso[S, S, ? <: Tuple, ? <: Tuple] but GenIso._fields still fed the result into `whitebox`, which expects Expr[Iso[S, A]]. The wildcard type no longer unifies with Iso[S, A], breaking macrosJVM compilation on every Scala 3 JVM job (the CI page only showed temurin@25 red because fail-fast cancelled the others).

Cast the IsoFields result directly to Expr[Iso[S, Any]] in the fallback branch, matching the erased cast `whitebox` already performs.