### PR TITLE
Fix GenIso.fields compilation after IsoFields wildcard change

### DIFF
--- a/macro/src/main/scala-3/monocle/macros/GenIso.scala
+++ b/macro/src/main/scala-3/monocle/macros/GenIso.scala
@@ -1,6 +1,6 @@
 package monocle.macros
 
-import monocle.Iso
+import monocle.{Iso, PIso}
 import scala.language.`3.0`
 import scala.deriving.*
 import scala.quoted.*
@@ -63,7 +63,7 @@ object GenIso {
 
   private def _fields[S <: Product](e: Expr[Mirror.ProductOf[S]])(using Quotes, Type[S]): Expr[Iso[S, Any]] = {
 
-    def whitebox[A](e: Expr[Iso[S, A]]): Expr[Iso[S, Any]] =
+    def whitebox(e: Expr[PIso[S, S, ?, ?]]): Expr[Iso[S, Any]] =
       e.asInstanceOf[Expr[Iso[S, Any]]]
 
     e match {


### PR DESCRIPTION
## Summary

CI on `master` is failing since #1574 with:

```
[E007] Type Mismatch Error: macro/src/main/scala-3/monocle/macros/GenIso.scala:77:49
77 |        whitebox('{ monocle.internal.IsoFields[S](using $e) })
   |          Found:    monocle.PIso[S, S, ? <: Tuple, ? <: Tuple]
   |          Required: monocle.Iso[S, A]
```

#1574 changed `IsoFields.apply` to return `PIso[S, S, ? <: Tuple, ? <: Tuple]`, but the fallback arm of `GenIso._fields` passes that expression to `whitebox[A](e: Expr[Iso[S, A]])`, and the wildcard type cannot unify with `Iso[S, A]` (which requires both type parameters to be the same `A`).

## Fix

Widen `whitebox` to accept `Expr[PIso[S, S, ?, ?]]`. All three match arms conform to it (`Expr` is covariant and `Iso[S, A] = PIso[S, S, A, A]`), and the cast it performs is unchanged. Since `GenIso.fields` is `transparent inline`, the precise type is still inferred at call sites.

## Verification

- `sbt '++ 3' macrosJVM/test`: compiles, 130/130 tests pass, including `GenIso.fields` on a two-field case class which exercises the fixed fallback arm.
- `sbt '++ 3' macrosJVM/scalafmtCheck`: passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)